### PR TITLE
Showcase multilingual dense retrieval with E5

### DIFF
--- a/notebooks/search/01-keyword-querying-filtering.ipynb
+++ b/notebooks/search/01-keyword-querying-filtering.ipynb
@@ -3,15 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0wgbLWl2udLQ"
-      },
-      "source": [
-        "[Quick Start](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/00-quick-start.ipynb) || **Keyword Querying Filtering** || [Hybrid search with RRF](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/02-hybrid-search.ipynb) || [ELSER](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/03-ELSER.ipynb)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "83LdOUCwwHzs"
       },
       "source": [

--- a/notebooks/search/04-multilingual.ipynb
+++ b/notebooks/search/04-multilingual.ipynb
@@ -1,0 +1,556 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s49gpkvZ7q53"
+   },
+   "source": [
+    "# Multilingual semantic search\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/main/blob/notebooks/search/04-multilingual.ipynb)\n",
+    "\n",
+    "In this example we'll use a multilingual embedding model\n",
+    "[multilingual-e5-base](https://huggingface.co/intfloat/multilingual-e5-base) to perform search on a toy dataset of mixed\n",
+    "language documents. Using this model, we can search in two ways:\n",
+    " * Across languages, for example using a query in German to find documents in English\n",
+    " * Within a non-English language, for example using a query in German to find documents in German\n",
+    "\n",
+    " While this example is using dense retrieval only, it's possible to also combine dense and tradition lexical retrieval\n",
+    " with hybrid search. For more information on lexical multilingual search, please see the blog post\n",
+    " [Multilingual search using language identification in Elasticsearch](https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch).\n",
+    "\n",
+    " The dataset used contains snippets of Wikipedia passages from the [MIRACL](https://project-miracl.github.io/) dataset."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Y01AXpELkygt"
+   },
+   "source": [
+    "# 🧰 Requirements\n",
+    "\n",
+    "For this example, you will need:\n",
+    "\n",
+    "- Python 3.6 or later\n",
+    "- An Elastic deployment with minimum **4GB machine learning node**\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page))\n",
+    "- The [Elastic Python client](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/installation.html)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N4pI1-eIvWrI"
+   },
+   "source": [
+    "## Create Elastic Cloud deployment\n",
+    "\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+    "\n",
+    "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
+    "   - Select **Create deployment**"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gaTFHLJC-Mgi"
+   },
+   "source": [
+    "# Install packages and initialize the Elasticsearch Python client\n",
+    "\n",
+    "To get started, we'll need to connect to our Elastic deployment using the Python client.\n",
+    "Because we're using an Elastic Cloud deployment, we'll use the **Cloud ID** to identify our deployment.\n",
+    "\n",
+    "First we need to `pip` install the packages we need for this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "K9Q1p2C9-wce",
+    "outputId": "204d5aee-571e-4363-be6e-f87d058f2d29"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install elasticsearch\n",
+    "!pip install sentence_transformers\n",
+    "!pip install torch"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gEzq2Z1wBs3M"
+   },
+   "source": [
+    "Next we need to import the `elasticsearch` module and the `getpass` module.\n",
+    "`getpass` is part of the Python standard library and is used to securely prompt for credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uP_GTVRi-d96"
+   },
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import textwrap\n",
+    "import torch\n",
+    "\n",
+    "from elasticsearch import Elasticsearch\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "model = SentenceTransformer(\"intfloat/multilingual-e5-base\", device=device)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AMSePFiZCRqX"
+   },
+   "source": [
+    "Now we can instantiate the Python Elasticsearch client.\n",
+    "First we prompt the user for their password and Cloud ID.\n",
+    "\n",
+    "🔐 NOTE: `getpass` enables us to securely prompt the user for credentials without echoing them to the terminal, or storing it in memory.\n",
+    "\n",
+    "Then we create a `client` object that instantiates an instance of the `Elasticsearch` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "h0MdAZ53CdKL",
+    "outputId": "96ea6f81-f935-4d51-c4a7-af5a896180f1"
+   },
+   "outputs": [],
+   "source": [
+    "# Found in the \"Manage Deployment\" page\n",
+    "CLOUD_ID = getpass.getpass(\"Enter Elastic Cloud ID:  \")\n",
+    "\n",
+    "# Password for the \"elastic\" user generated by Elasticsearch\n",
+    "ELASTIC_PASSWORD = getpass.getpass(\"Enter Elastic password:  \")\n",
+    "\n",
+    "# Create the client instance\n",
+    "client = Elasticsearch(\n",
+    "    cloud_id=CLOUD_ID,\n",
+    "    basic_auth=(\"elastic\", ELASTIC_PASSWORD)\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bRHbecNeEDL3"
+   },
+   "source": [
+    "Confirm that the client has connected with this test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "rdiUKqZbEKfF",
+    "outputId": "43b6f1cd-a43e-4dbe-caa5-7fd170464881"
+   },
+   "outputs": [],
+   "source": [
+    "print(client.info())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "enHQuT57DhD1"
+   },
+   "source": [
+    "Refer to https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connect-self-managed-new to learn how to connect to a self-managed deployment.\n",
+    "\n",
+    "Read https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connect-self-managed-new to learn how to connect using API keys.\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TF_wxIAhD07a"
+   },
+   "source": [
+    "# Create Elasticsearch index with required mappings\n",
+    "\n",
+    "We need to add a field to support dense vector storage and search.\n",
+    "Note the `passage_embedding` field below, which is used to store the dense vector representation of the `passage` field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "cvYECABJJs_2",
+    "outputId": "18fb51e4-c4f6-4d1b-cb2d-bc6f8ec1aa84"
+   },
+   "outputs": [],
+   "source": [
+    "# Define the mapping\n",
+    "mapping = {\n",
+    "    \"mappings\": {\n",
+    "        \"properties\": {\n",
+    "            \"language\": {\"type\": \"keyword\"},\n",
+    "            \"id\": {\"type\": \"keyword\"},\n",
+    "            \"title\": {\"type\": \"text\"},\n",
+    "            \"passage\": {\"type\": \"text\"},\n",
+    "            \"passage_embedding\": {\n",
+    "                \"type\": \"dense_vector\",\n",
+    "                \"dims\": 768,\n",
+    "                \"index\": \"true\",\n",
+    "                \"similarity\": \"cosine\"\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Create the index (deleting any existing index)\n",
+    "client.indices.delete(index=\"articles\", ignore_unavailable=True)\n",
+    "client.indices.create(index=\"articles\", body=mapping)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset\n",
+    "\n",
+    "Let's index some data.\n",
+    "Note that we are embedding the `passage` field using the sentence transformer model.\n",
+    "Once indexed, you'll see that your documents contain a `passage_embedding` field (`\"type\": \"dense_vector\"`) which contains a vector of floating point values.\n",
+    "This is the embedding of the `passage` field in vector space.\n",
+    "We'll use this field to perform semantic search using kNN."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "articles = [\n",
+    "    {\n",
+    "        \"language\": \"en\",\n",
+    "        \"id\": \"1643584#0\",\n",
+    "        \"title\": \"Bloor Street\",\n",
+    "        \"passage\": \"\"\"Bloor Street is a major east–west residential and commercial thoroughfare in Toronto, Ontario, Canada. Bloor Street runs from the Prince Edward Viaduct, which spans the Don River Valley, westward into Mississauga where it ends at Central Parkway. East of the viaduct, Danforth Avenue continues along the same right-of-way. The street, approximately long, contains a significant cross-sample of Toronto's ethnic communities. It is also home to Toronto's famous shopping street, the Mink Mile.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"en\",\n",
+    "        \"id\": \"2190499#0\",\n",
+    "        \"title\": \"Elphinstone College\",\n",
+    "        \"passage\": \"\"\"Elphinstone College is an institution of higher education affiliated to the University of Mumbai. Established in 1856, it is one of the oldest colleges of the University of Mumbai. It is reputed for producing luminaries like Bal Gangadhar Tilak, Bhim Rao Ambedkar, Virchand Gandhi, Badruddin Tyabji, Pherozshah Mehta, Kashinath Trimbak Telang, Jamsetji Tata and for illustrious professors that includes Dadabhai Naoroji. It is further observed for having played a key role in spread of Western education in the Bombay Presidency.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"en\",\n",
+    "        \"id\": \"8881#0\",\n",
+    "        \"title\": \"Doctor (title)\",\n",
+    "        \"passage\": \"\"\"Doctor is an academic title that originates from the Latin word of the same spelling and meaning. The word is originally an agentive noun of the Latin verb \"\" 'to teach'. It has been used as an academic title in Europe since the 13th century, when the first Doctorates were awarded at the University of Bologna and the University of Paris. Having become established in European universities, this usage spread around the world. Contracted \"Dr\" or \"Dr.\", it is used as a designation for a person who has obtained a Doctorate (e.g. PhD). In many parts of the world it is also used by medical practitioners, regardless of whether or not they hold a doctoral-level degree.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"de\",\n",
+    "        \"id\": \"9002#0\",\n",
+    "        \"title\": \"Gesundheits- und Krankenpflege\",\n",
+    "        \"passage\": \"\"\"Die Gesundheits- und Krankenpflege als Berufsfeld umfasst die Versorgung und Betreuung von Menschen aller Altersgruppen, insbesondere kranke, behinderte und sterbende Erwachsene. Die Gesundheits- und Kinderkrankenpflege hat ihren Schwerpunkt in der Versorgung von Kindern und Jugendlichen. In beiden Fachrichtungen gehört die Verhütung von Krankheiten und Gesunderhaltung zum Aufgabengebiet der professionellen Pflege.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"de\",\n",
+    "        \"id\": \"7769762#0\",\n",
+    "        \"title\": \"Tourismusregion (Österreich)\",\n",
+    "        \"passage\": \"\"\"Unter Tourismusregion versteht man in Österreich die in den Landestourismusgesetzen verankerten Tourismusverbände mehrerer Gemeinden, im weiteren Sinne aller Gebietskörperschaften.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"de\",\n",
+    "        \"id\": \"2270104#0\",\n",
+    "        \"title\": \"London Wall\",\n",
+    "        \"passage\": \"\"\"London Wall ist die strategische Stadtmauer, die die Römer um Londinium gebaut haben, um die Stadt zu schützen, die über den wichtigen Hafen an der Themse verfügte. Bis ins späte Mittelalter hinein bildete diese Stadtmauer die Grenzen von London. Heute ist \"London Wall\" auch der Name einer Straße, die an einem noch bestehenden Abschnitt der Stadtmauer verläuft.\"\"\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"language\": \"de\",\n",
+    "        \"id\": \"2270104#1\",\n",
+    "        \"title\": \"London Wall\",\n",
+    "        \"passage\": \"\"\"Die Mauer wurde Ende des zweiten oder Anfang des dritten Jahrhunderts erbaut, wahrscheinlich zwischen 190 und 225, vermutlich zwischen 200 und 220. Sie entstand somit etwa achtzig Jahre nach dem im Jahr 120 erfolgten Bau der Festung, deren nördliche und westliche Mauern verstärkt und in der Höhe verdoppelt wurden, um einen Teil der neuen Stadtmauer zu bilden. Die Anlage wurde zumindest bis zum Ende des vierten Jahrhunderts weiter ausgebaut. Sie zählt zu den letzten großen Bauprojekten der Römer vor deren Rückzug aus Britannien im Jahr 410.\"\"\",\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Index documents\n",
+    "\n",
+    "Our dataset is a Python list that contains dictionaries of passages from Wikipedia articles in two languages.\n",
+    "We'll use the `helpers.bulk` method to index our documents in batches.\n",
+    "\n",
+    "The following code iterates over the articles and creates a list of actions to be performed.\n",
+    "Each action is a dictionary containing an \"index\" operation on our Elasticsearch index.\n",
+    "The passage is encoded using our selected model, and the encoded vector is added to the article document.\n",
+    "Note that the E5 models require that a prefix instruction is used \"passage: \" to tell the model that it is to embed a passage.\n",
+    "On the query side, the query string will be prefixed with \"query: \".\n",
+    "The article document is then added to the list of actions.\n",
+    "\n",
+    "Finally, we call the `bulk` method, specifying the index name and the list of actions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actions = []\n",
+    "for article in articles:\n",
+    "    actions.append({\"index\": {\"_index\": \"articles\"}})\n",
+    "    passage = article[\"passage\"]\n",
+    "    passageEmbedding = model.encode(f\"passage: {passage}\").tolist()\n",
+    "    article[\"passage_embedding\"] = passageEmbedding\n",
+    "    actions.append(article)\n",
+    "\n",
+    "client.bulk(index=\"articles\", operations=actions)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MrBCHdH1u8Wd"
+   },
+   "source": [
+    "# Multilingual Semantic Search\n",
+    "\n",
+    "In the following, we will search using two kinds of queries:\n",
+    " * Query in English to find documents in any language\n",
+    " * Query in German to find documents in German only (using a filter),\n",
+    "   to show the model's capabilities in non-English languages\n",
+    "\n",
+    "Note again that the query is prefixed with \"query: \", which the model requires to encode the query properly.\n",
+    "\n",
+    "A quick translation for those unfamiliar with German:\n",
+    " * \"health\" -> \"Gesundheit\"\n",
+    " * \"wall\" -> \"Mauer\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pretty_response(response):\n",
+    "    for hit in response[\"hits\"][\"hits\"]:\n",
+    "        score = hit[\"_score\"]\n",
+    "        language = hit[\"_source\"][\"language\"]\n",
+    "        id = hit[\"_source\"][\"id\"]\n",
+    "        title = hit[\"_source\"][\"title\"]\n",
+    "        passage = hit[\"_source\"][\"passage\"]\n",
+    "        print()\n",
+    "        print(f\"ID: {id}\")\n",
+    "        print(f\"Language: {language}\")\n",
+    "        print(f\"Title: {title}\")\n",
+    "        print(f\"Passage: {textwrap.fill(passage, 120)}\")\n",
+    "        print(f\"Score: {score}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query(q, language=None):\n",
+    "    knn = {\n",
+    "        \"field\": \"passage_embedding\",\n",
+    "        \"query_vector\" : model.encode(f\"query: {q}\").tolist(),\n",
+    "        \"k\": 2,\n",
+    "        \"num_candidates\": 5\n",
+    "    }\n",
+    "\n",
+    "    if language:\n",
+    "        knn[\"filter\"] = {\n",
+    "            \"term\": {\n",
+    "                \"language\": language,\n",
+    "            }\n",
+    "        }\n",
+    "\n",
+    "    return client.search(index=\"articles\", knn=knn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ID: 9002#0\n",
+      "Language: de\n",
+      "Title: Gesundheits- und Krankenpflege\n",
+      "Passage: Die Gesundheits- und Krankenpflege als Berufsfeld umfasst die Versorgung und Betreuung von Menschen aller Altersgruppen,\n",
+      "insbesondere kranke, behinderte und sterbende Erwachsene. Die Gesundheits- und Kinderkrankenpflege hat ihren Schwerpunkt\n",
+      "in der Versorgung von Kindern und Jugendlichen. In beiden Fachrichtungen gehört die Verhütung von Krankheiten und\n",
+      "Gesunderhaltung zum Aufgabengebiet der professionellen Pflege.\n",
+      "Score: 0.8986236\n",
+      "\n",
+      "ID: 8881#0\n",
+      "Language: en\n",
+      "Title: Doctor (title)\n",
+      "Passage: Doctor is an academic title that originates from the Latin word of the same spelling and meaning. The word is originally\n",
+      "an agentive noun of the Latin verb \"\" 'to teach'. It has been used as an academic title in Europe since the 13th\n",
+      "century, when the first Doctorates were awarded at the University of Bologna and the University of Paris. Having become\n",
+      "established in European universities, this usage spread around the world. Contracted \"Dr\" or \"Dr.\", it is used as a\n",
+      "designation for a person who has obtained a Doctorate (e.g. PhD). In many parts of the world it is also used by medical\n",
+      "practitioners, regardless of whether or not they hold a doctoral-level degree.\n",
+      "Score: 0.89126843\n"
+     ]
+    }
+   ],
+   "source": [
+    "pretty_response(query(\"health\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in the results above, we see that the document about healthcare,\n",
+    "even though it's in German, matches better to the query \"health\",\n",
+    "versus the English document which doesn't talk about health specifically but about doctors more generally.\n",
+    "This is the power of a multilingual embedding which embeds meaning across languages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ID: 2270104#0\n",
+      "Language: de\n",
+      "Title: London Wall\n",
+      "Passage: London Wall ist die strategische Stadtmauer, die die Römer um Londinium gebaut haben, um die Stadt zu schützen, die über\n",
+      "den wichtigen Hafen an der Themse verfügte. Bis ins späte Mittelalter hinein bildete diese Stadtmauer die Grenzen von\n",
+      "London. Heute ist \"London Wall\" auch der Name einer Straße, die an einem noch bestehenden Abschnitt der Stadtmauer\n",
+      "verläuft.\n",
+      "Score: 0.8941859\n",
+      "\n",
+      "ID: 2270104#1\n",
+      "Language: de\n",
+      "Title: London Wall\n",
+      "Passage: Die Mauer wurde Ende des zweiten oder Anfang des dritten Jahrhunderts erbaut, wahrscheinlich zwischen 190 und 225,\n",
+      "vermutlich zwischen 200 und 220. Sie entstand somit etwa achtzig Jahre nach dem im Jahr 120 erfolgten Bau der Festung,\n",
+      "deren nördliche und westliche Mauern verstärkt und in der Höhe verdoppelt wurden, um einen Teil der neuen Stadtmauer zu\n",
+      "bilden. Die Anlage wurde zumindest bis zum Ende des vierten Jahrhunderts weiter ausgebaut. Sie zählt zu den letzten\n",
+      "großen Bauprojekten der Römer vor deren Rückzug aus Britannien im Jahr 410.\n",
+      "Score: 0.8700954\n"
+     ]
+    }
+   ],
+   "source": [
+    "pretty_response(query(\"wall\", language=\"de\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ID: 2270104#1\n",
+      "Language: de\n",
+      "Title: London Wall\n",
+      "Passage: Die Mauer wurde Ende des zweiten oder Anfang des dritten Jahrhunderts erbaut, wahrscheinlich zwischen 190 und 225,\n",
+      "vermutlich zwischen 200 und 220. Sie entstand somit etwa achtzig Jahre nach dem im Jahr 120 erfolgten Bau der Festung,\n",
+      "deren nördliche und westliche Mauern verstärkt und in der Höhe verdoppelt wurden, um einen Teil der neuen Stadtmauer zu\n",
+      "bilden. Die Anlage wurde zumindest bis zum Ende des vierten Jahrhunderts weiter ausgebaut. Sie zählt zu den letzten\n",
+      "großen Bauprojekten der Römer vor deren Rückzug aus Britannien im Jahr 410.\n",
+      "Score: 0.88160384\n",
+      "\n",
+      "ID: 2270104#0\n",
+      "Language: de\n",
+      "Title: London Wall\n",
+      "Passage: London Wall ist die strategische Stadtmauer, die die Römer um Londinium gebaut haben, um die Stadt zu schützen, die über\n",
+      "den wichtigen Hafen an der Themse verfügte. Bis ins späte Mittelalter hinein bildete diese Stadtmauer die Grenzen von\n",
+      "London. Heute ist \"London Wall\" auch der Name einer Straße, die an einem noch bestehenden Abschnitt der Stadtmauer\n",
+      "verläuft.\n",
+      "Score: 0.8761389\n"
+     ]
+    }
+   ],
+   "source": [
+    "pretty_response(query(\"Mauer\", language=\"de\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/search/README.md
+++ b/notebooks/search/README.md
@@ -8,6 +8,7 @@ The following notebooks are available:
 1. [Keyword, querying, filtering](#1-keyword-querying-filtering)
 2. [Hybrid search](#2-hybrid-search)
 3. [Semantic search with ELSER](#3-semantic-search-with-elser)
+4. [Multilingual semantic search](#4-multilingual-semantic-search)
 
 ## Notebooks
 
@@ -54,3 +55,12 @@ In the [`03-ELSER.ipynb`](./03-ELSER.ipynb) notebook, you'll learn how to:
 - Observe the results of running the documents through the model by inspecting the additional terms it adds to documents, which enhance searchability.
 - Perform simple keyword searches on the `elser-movies` index to assess the impact of ELSER's text expansion.
 - Execute ELSER-powered semantic searches using the `text_expansion` query.
+
+### 4. Multilingual semantic search
+
+In the [`04-multilingual.ipynb`](./04-multilingual.ipynb) notebook, you'll learn how to:
+
+- Use a multilingual embedding model for semantic search across languages.
+- Transform fields in the sample dataset into embeddings using the Sentence Transformer model and index them into Elasticsearch.
+- Use filtering with a `kNN` semantic search.
+- Walk through a super simple toy example that demonstrates, step by step, how multilingual search works across languages, and within non-English languages.


### PR DESCRIPTION
This new notebook shows a simple walkthrough of using the E5 multilingual embedding model to query a mixed language corpus. It follows the same level of abstraction and details as the other notebooks in this directory, opting to perform all inference outside of the stack. We use select passages from the MIRACL dataset in English and German.