### PR TITLE
Fix colab link for open-knn-rag notebook file

### DIFF
--- a/notebooks/integrations/openai/openai-KNN-RAG.ipynb
+++ b/notebooks/integrations/openai/openai-KNN-RAG.ipynb
@@ -13,7 +13,7 @@
    "id": "e0f537af",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/elastic/elasticsearch-labs/tree/main/notebooks/integrations/openai/openai-KNN-RAG.ipynb)\n"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/openai/openai-KNN-RAG.ipynb)\n"
    ]
   },
   {


### PR DESCRIPTION
Update correct [colab](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/openai/openai-KNN-RAG.ipynb) url
