### PR TITLE
Add tiktoken dependency

### DIFF
--- a/notebooks/generative-ai/chatbot.ipynb
+++ b/notebooks/generative-ai/chatbot.ipynb
@@ -55,7 +55,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -U langchain==0.0.245 openai elasticsearch"
+    "%pip install -U langchain==0.0.245 openai elasticsearch tiktoken"
    ]
   },
   {


### PR DESCRIPTION
Tiktoken is needed for the OpenAI LangChain plugin:

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
/usr/local/lib/python3.10/dist-packages/langchain/embeddings/openai.py in _get_len_safe_embeddings(self, texts, engine, chunk_size)
    312         try:
--> 313             import tiktoken
    314         except ImportError:

ModuleNotFoundError: No module named 'tiktoken'
```