### PR TITLE
Fixed broken collab link

### DIFF
--- a/notebooks/langchain/langchain-self-query-retriever.ipynb
+++ b/notebooks/langchain/langchain-self-query-retriever.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Self-querying retriever with elasticsearch and langchain\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/langchain/langchain-self-query-retriever.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/langchain/langchain-self-query-retriever.ipynb)\n",
     "\n",
     "This workbook demonstrates example of Elasticsearch's [Self-query retriever](https://api.python.langchain.com/en/latest/retrievers/langchain.retrievers.self_query.base.SelfQueryRetriever.html) to convert unstructured query into a structured query and apply structured query to a vectorstore. \n",
     "\n",


### PR DESCRIPTION
It looks like the langchain examples got moved from the integrations folder but the link wasn't updated so it caused a 404