### PR TITLE
Import elasticsearch-labs Github repo in chatbot.ipynb

### DIFF
--- a/notebooks/generative-ai/chatbot.ipynb
+++ b/notebooks/generative-ai/chatbot.ipynb
@@ -11,10 +11,11 @@
     "In this notebook we'll build a chatbot that can respond to questions about custom data, such as policies of an employer.\n",
     "\n",
     "The chatbot uses LangChain's `ConversationalRetrievalChain` and has the following capabilities:\n",
+    "\n",
     "- Answer questions asked in natural language\n",
     "- Run hybrid search in Elasticsearch to find documents that answer the question\n",
     "- Extract and summarize the answer using OpenAI LLM\n",
-    "- Maintain conversational memory for follow-up questions"
+    "- Maintain conversational memory for follow-up questions\n"
    ]
   },
   {
@@ -22,6 +23,7 @@
    "metadata": {},
    "source": [
     "## Requirements 🧰\n",
+    "\n",
     "For this example, you will need:\n",
     "\n",
     "- Python 3.6 or later\n",
@@ -32,8 +34,9 @@
     "### Create Elastic Cloud deployment\n",
     "\n",
     "If you don't have an Elastic Cloud deployment, follow these steps to create one.\n",
+    "\n",
     "1. Go to https://cloud.elastic.co/registration and sign up for a free trial\n",
-    "2. Select **Create Deployment** and follow the instructions"
+    "2. Select **Create Deployment** and follow the instructions\n"
    ]
   },
   {
@@ -42,7 +45,7 @@
    "source": [
     "## Install packages 📦\n",
     "\n",
-    "First we `pip install` the packages we need for this example."
+    "First we `pip install` the packages we need for this example.\n"
    ]
   },
   {
@@ -62,9 +65,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Add Elasticsearch Chat History Module Path\n",
+    "\n",
+    "We will be using a custom module that needs to be loaded into Colab. We will do this by cloning the Elasticsearch Labs Github repo and adding it to the path.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/elastic/elasticsearch-labs.git\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('/content/elasticsearch-labs/notebooks/generative-ai')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Initialize clients 🔌\n",
     "\n",
-    "Next we input credentials with `getpass`. `getpass` is part of the Python standard library and is used to securely prompt for credentials."
+    "Next we input credentials with `getpass`. `getpass` is part of the Python standard library and is used to securely prompt for credentials.\n"
    ]
   },
   {
@@ -87,7 +115,7 @@
    "source": [
     "## Load and process documents 📄\n",
     "\n",
-    "Time to load some data! We'll be using the workplace search example data, which is a list of employee documents and policies."
+    "Time to load some data! We'll be using the workplace search example data, which is a list of employee documents and policies.\n"
    ]
   },
   {
@@ -124,7 +152,7 @@
     "\n",
     "As we're chatting with our bot, it will run semantic searches on the index to find the relevant documents. In order for this to be accurate, we need to split the full documents into small chunks (also called passages). This way the semantic search will find the passage within a document that most likely answers our question.\n",
     "\n",
-    "We'll use LangChain's `CharacterTextSplitter` and split the documents' text at 800 characters with some overlap between chunks."
+    "We'll use LangChain's `CharacterTextSplitter` and split the documents' text at 800 characters with some overlap between chunks.\n"
    ]
   },
   {
@@ -174,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's generate the embeddings and index the documents with them."
+    "Let's generate the embeddings and index the documents with them.\n"
    ]
   },
   {
@@ -204,7 +232,7 @@
    "source": [
     "## Chat with the chatbot 💬\n",
     "\n",
-    "Let's initialize our chatbot. We'll define Elasticsearch as a store for retrieving documents and for storing the chat session history, OpenAI as the LLM to interpret questions and summarize answers, then we'll pass these to the conversational chain."
+    "Let's initialize our chatbot. We'll define Elasticsearch as a store for retrieving documents and for storing the chat session history, OpenAI as the LLM to interpret questions and summarize answers, then we'll pass these to the conversational chain.\n"
    ]
   },
   {
@@ -243,7 +271,7 @@
    "source": [
     "Now we can ask questions from our chatbot!\n",
     "\n",
-    "See how the chat history is passed as context for each question."
+    "See how the chat history is passed as context for each question.\n"
    ]
   },
   {
@@ -289,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "💡 _Try experimenting with other questions or after clearing the workplace data, and observe how the responses change._"
+    "💡 _Try experimenting with other questions or after clearing the workplace data, and observe how the responses change._\n"
    ]
   },
   {
@@ -298,7 +326,7 @@
    "source": [
     "# (Optional) Clean up 🧹\n",
     "\n",
-    "Once we're done, we can clean up the chat history for this session..."
+    "Once we're done, we can clean up the chat history for this session...\n"
    ]
   },
   {
@@ -314,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "... or delete the indices."
+    "... or delete the indices.\n"
    ]
   },
   {


### PR DESCRIPTION
The `lib.elasticsearch_chat_message_history` module cannot be imported in Google Colab. Importing the elasticsearch-labs Github repo and adding it to the path fixes this. 