### PR TITLE
Minor: restore index name

### DIFF
--- a/notebooks/generative-ai/chatbot.ipynb
+++ b/notebooks/generative-ai/chatbot.ipynb
@@ -193,7 +193,7 @@
     "    es_cloud_id=ELASTIC_CLOUD_ID, \n",
     "    es_user=ELASTIC_USERNAME, \n",
     "    es_password=ELASTIC_PASSWORD,\n",
-    "    index_name=\"workplace_index\",\n",
+    "    index_name=\"workplace-docs\",\n",
     "    embedding=embeddings\n",
     ")"
    ]
@@ -334,7 +334,7 @@
     }
    ],
    "source": [
-    "vector_store.client.indices.delete(index='workplace_index')\n",
+    "vector_store.client.indices.delete(index='workplace-docs')\n",
     "vector_store.client.indices.delete(index='workplace-docs-chat-history')"
    ]
   }


### PR DESCRIPTION
Restore `workplace-docs` index name from `workplace_index` for these reasons:
- Naming consistency (kebab case)
- Alignment with `workplace-docs-chat-history` index