### PR TITLE
Fix incorrect file url

### DIFF
--- a/notebooks/search/00-quick-start.ipynb
+++ b/notebooks/search/00-quick-start.ipynb
@@ -255,7 +255,7 @@
         "import json\n",
         "from urllib.request import urlopen\n",
         "\n",
-        "url = \"https://raw.githubusercontent.com/elastic/elasticsearch-labs/blob/main/search/data.json\"\n",
+        "url = \"https://raw.githubusercontent.com/elastic/elasticsearch-labs/main/notebooks/search/data.json\"\n",
         "response = urlopen(url)\n",
         "books = json.loads(response.read())\n",
         "\n",


### PR DESCRIPTION
In the "Semantic Search Quick Start" example,
404 error occurs because the url of the index test data is incorrect.
I modified the url correctly.