### PR TITLE
[docs] Add note about TOC to developer guide

### DIFF
--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,4 +1,8 @@
+
 # Elasticsearch Developer Guide
+
+> ℹ️ You can see a **table of contents** for this guide by by clicking the menu icon <img width="28" alt="Screenshot 2023-08-31 at 17 08 56" src="https://github.com/elastic/elasticsearch-labs/assets/32779855/becbabae-798b-409e-ae4d-506beff113ec">
+at the top of this page.
 
 This guide is intended for developers who want to build applications that combine Elasticsearch with generative AI.
 - [Introduction](#introduction)

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,7 +1,7 @@
 
 # Elasticsearch Developer Guide
 
-> ℹ️ You can see a **table of contents** for this guide by by clicking the menu icon <img width="28" alt="Screenshot 2023-08-31 at 17 08 56" src="https://github.com/elastic/elasticsearch-labs/assets/32779855/becbabae-798b-409e-ae4d-506beff113ec">
+> ℹ️ You can see a **table of contents** for this guide by clicking the menu icon <img width="28" alt="Screenshot 2023-08-31 at 17 08 56" src="https://github.com/elastic/elasticsearch-labs/assets/32779855/becbabae-798b-409e-ae4d-506beff113ec">
 at the top of this page.
 
 This guide is intended for developers who want to build applications that combine Elasticsearch with generative AI.


### PR DESCRIPTION
Totally optional, but just reminds folks that there's a nice built-in TOC for markdown files, which is pretty handy and improves the reading experience for longer content.

Screenshot:
<img width="954" alt="Screenshot 2023-08-31 at 17 44 31" src="https://github.com/elastic/elasticsearch-labs/assets/32779855/5206374e-cf79-4f3d-8ce5-e567c763d121">


