### PR TITLE
Update elastic cloud sign up link with trackable url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Prior to opening a pull request, please:
 - Create an issue to [discuss the scope of your proposal](https://github.com/elastic/elasticsearch-labs/issues). We are happy to provide guidance to make for a pleasant contribution experience.
 - Sign the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 
+## General instruction
+
+- If the notebook or code sample requires signing up a Elastic cloud instance, make sure to add appropriate `utm_source` and `utm_content` in the cloud registration url. For example, the Elastic cloud sign up url for the Python notebooks should have `utm_source=github&utm_content=elasticsearch-labs-notebook` and code examples should have `utm_source=github&utm_content=elasticsearch-labs-samples`.
+  
 ## Contributing to Python notebooks 📒
 
 ### Why

--- a/example-apps/openai-embeddings/README.md
+++ b/example-apps/openai-embeddings/README.md
@@ -38,7 +38,7 @@ tar -xz --strip=2 elasticsearch-labs-main/example-apps/openai-embeddings
 
 ### 3. Create Elastic Cloud account and credentials
 
-- Go to https://cloud.elastic.co/ and sign up
+- [Sign up](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-samples) for a Elastic cloud account
 - Make note of the master username/password shown to you during creation of the deployment
 - Make note of the Elastic Cloud ID after the deployment
 

--- a/example-apps/relevance-workbench/README.md
+++ b/example-apps/relevance-workbench/README.md
@@ -14,7 +14,7 @@ To run this demo successfully, you will need an Elasticsearch deployment (> 8.8)
 
 ## Deploy Elasticsearch in Elastic Cloud
 
-If you don't have an Elastic Cloud account, you can start by signing up for a [free Elastic Cloud trial](https://cloud.elastic.co/registration). After creating an account, you’ll have an active subscription, and you’ll be prompted to create your first deployment.
+If you don't have an Elastic Cloud account, you can start by signing up for a [free Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-samples). After creating an account, you’ll have an active subscription, and you’ll be prompted to create your first deployment.
 
 Follow the steps to Create a new deployment. For more details, refer to [Create a deployment](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) in the Elastic Cloud documentation.
 
@@ -87,7 +87,7 @@ python3 index-data.py --es_password=<ELASTICSEARCH_PASSWORD> --cloud_id=<CLOUD_I
 - ELASTICSEARCH_PASSWORD: Use the default admin password previously saved
 - CLOUD_ID: See instructions above to retrieve it
 
-Note that by default, only  subset of the dataset (100 movies) is indexed. If you're interested in indexing the whole data (7918 movies), you can select the `movies.json.gz` file by adding the option `--gzip_file=movies.json.gz` to the command line. Note that it might take up to 1 hour to index the full dataset.
+Note that by default, only subset of the dataset (100 movies) is indexed. If you're interested in indexing the whole data (7918 movies), you can select the `movies.json.gz` file by adding the option `--gzip_file=movies.json.gz` to the command line. Note that it might take up to 1 hour to index the full dataset.
 
 ## Run the application
 
@@ -96,6 +96,7 @@ Once the data have been successfully indexed, you can run the application to sta
 The application is composed of a backend Python API and a React frontend. You can run the whole application locally using Docker compose.
 
 Edit the `docker-compose.yml` file to replace values for. Reuse the same information that you use for loading the data.
+
 - CLOUD_ID=<CLOUD_ID>
 - ELASTICSEARCH_PASSWORD=<ELASTICSEARCH_PASSWORD>
 
@@ -170,6 +171,7 @@ datasets = {
 ```
 
 In the configuration of the new dataset, provides the following informations:
+
 - index: Name of the index
 - search_fields: Fields to query for BM25
 - elser_search_fields: Fields to query for ELSER

--- a/example-apps/workplace-search/README.md
+++ b/example-apps/workplace-search/README.md
@@ -24,8 +24,14 @@ export ELASTIC_PASSWORD=...
 export OPENAI_API_KEY=...
 ```
 
-Note: you can get your OpenAI key from the [OpenAI dashboard](https://platform.openai.com/account/api-keys).
+Note:
 
+- If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-samples) for a free trial.
+
+  1. Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page
+  2. Select **Create deployment** and follow the instructions
+
+- you can get your OpenAI key from the [OpenAI dashboard](https://platform.openai.com/account/api-keys).
 
 ## 3. Index Data
 

--- a/notebooks/generative-ai/chatbot.ipynb
+++ b/notebooks/generative-ai/chatbot.ipynb
@@ -28,14 +28,14 @@
     "\n",
     "- Python 3.6 or later\n",
     "- An Elastic deployment\n",
-    "  - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration))\n",
+    "  - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "- OpenAI account\n",
     "\n",
     "### Create Elastic Cloud deployment\n",
     "\n",
     "If you don't have an Elastic Cloud deployment, follow these steps to create one.\n",
     "\n",
-    "1. Go to https://cloud.elastic.co/registration and sign up for a free trial\n",
+    "1. Go to [Elastic cloud Registration](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) and sign up for a free trial\n",
     "2. Select **Create Deployment** and follow the instructions\n"
    ]
   },
@@ -369,7 +369,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3.11.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -383,9 +383,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.3"
+   "version": "3.11.4"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/notebooks/generative-ai/question-answering.ipynb
+++ b/notebooks/generative-ai/question-answering.ipynb
@@ -61,7 +61,7 @@
       "source": [
         "## Connect to Elasticsearch\n",
         "\n",
-        "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial. \n",
+        "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial. \n",
         "\n",
         "We'll use the **Cloud ID** to identify our deployment, because we are using Elastic Cloud deployment. To find the Cloud ID for your deployment, go to https://cloud.elastic.co/deployments and select your deployment.\n",
         "\n",

--- a/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
+++ b/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
@@ -18,7 +18,7 @@
     "## Prerequisities\n",
     "Before we begin, create an elastic cloud deployment and [autoscale](https://www.elastic.co/guide/en/cloud/current/ec-autoscaling.html) to have least one machine learning (ML) node with enough (4GB) memory. Also ensure that the Elasticsearch cluster is running. \n",
     "\n",
-    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?fromURI=%2Fhome).\n",
+    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook).\n",
     "\n"
    ]
   },
@@ -477,7 +477,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.11.3"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/integrations/openai/openai-KNN-RAG.ipynb
+++ b/notebooks/integrations/openai/openai-KNN-RAG.ipynb
@@ -62,7 +62,7 @@
     "## Connect to Elasticsearch\n",
     "\n",
     "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook.\n",
-    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?fromURI=%2Fhome).\n",
+    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=openai-cookbook).\n",
     "\n",
     "To connect to Elasticsearch, you need to create a client instance with the Cloud ID and password for your deployment.\n",
     "\n",
@@ -456,7 +456,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/notebooks/langchain/langchain-self-query-retriever.ipynb
+++ b/notebooks/langchain/langchain-self-query-retriever.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "## Connect to Elasticsearch\n",
     "\n",
-    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial. \n",
+    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial. \n",
     "\n",
     "We'll use the **Cloud ID** to identify our deployment, because we are using Elastic Cloud deployment. To find the Cloud ID for your deployment, go to https://cloud.elastic.co/deployments and select your deployment.\n",
     "\n",

--- a/notebooks/langchain/langchain-using-own-model.ipynb
+++ b/notebooks/langchain/langchain-using-own-model.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "## Connect to Elasticsearch\n",
     "\n",
-    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up here for a free trial.\n",
+    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
     "\n",
     "We'll use the Cloud ID to identify our deployment, because we are using Elastic Cloud deployment. To find the Cloud ID for your deployment, go to https://cloud.elastic.co/deployments and select your deployment.\n",
     "\n",

--- a/notebooks/langchain/langchain-vector-store-using-elser.ipynb
+++ b/notebooks/langchain/langchain-vector-store-using-elser.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "## Connect to Elasticsearch\n",
     "\n",
-    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial. \n",
+    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial. \n",
     "\n",
     "We'll use the **Cloud ID** to identify our deployment, because we are using Elastic Cloud deployment. To find the Cloud ID for your deployment, go to https://cloud.elastic.co/deployments and select your deployment.\n",
     "\n",

--- a/notebooks/langchain/langchain-vector-store.ipynb
+++ b/notebooks/langchain/langchain-vector-store.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "## Connect to Elasticsearch\n",
     "\n",
-    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial. \n",
+    "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook. If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial. \n",
     "\n",
     "We'll use the **Cloud ID** to identify our deployment, because we are using Elastic Cloud deployment. To find the Cloud ID for your deployment, go to https://cloud.elastic.co/deployments and select your deployment.\n",
     "\n",

--- a/notebooks/search/00-quick-start.ipynb
+++ b/notebooks/search/00-quick-start.ipynb
@@ -24,7 +24,7 @@
       "source": [
         "## Create Elastic Cloud deployment\n",
         "\n",
-        "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+        "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
         "\n",
         "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
         "   - Select **Create deployment**"

--- a/notebooks/search/01-keyword-querying-filtering.ipynb
+++ b/notebooks/search/01-keyword-querying-filtering.ipynb
@@ -1731,11 +1731,18 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "Python 3.11.4 64-bit",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "version": "3.11.4"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+      }
     }
   },
   "nbformat": 4,

--- a/notebooks/search/02-hybrid-search.ipynb
+++ b/notebooks/search/02-hybrid-search.ipynb
@@ -30,7 +30,8 @@
     "For this example, you will need:\n",
     "\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page))\n"
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
+    "   "
    ]
   },
   {
@@ -42,7 +43,7 @@
    "source": [
     "# Create Elastic Cloud deployment\n",
     "\n",
-    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
     "\n",
     "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
     "   - Under **Advanced settings**, go to **Machine Learning instances**\n",

--- a/notebooks/search/02-hybrid-search.ipynb
+++ b/notebooks/search/02-hybrid-search.ipynb
@@ -30,7 +30,7 @@
     "For this example, you will need:\n",
     "\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "   "
    ]
   },
@@ -598,7 +598,8 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.11.4 64-bit",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -611,7 +612,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.3"
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/search/03-ELSER.ipynb
+++ b/notebooks/search/03-ELSER.ipynb
@@ -27,7 +27,7 @@
     "For this example, you will need:\n",
     "\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "\n",
     "   \n"
    ]
@@ -41,7 +41,7 @@
    "source": [
     "# Create Elastic Cloud deployment\n",
     "\n",
-    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?fromURI=%2Fhome) for a free trial.\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
     "\n",
     "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
     "   - Under **Advanced settings**, go to **Machine Learning instances**\n",

--- a/notebooks/search/03-ELSER.ipynb
+++ b/notebooks/search/03-ELSER.ipynb
@@ -27,7 +27,9 @@
     "For this example, you will need:\n",
     "\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page))\n"
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](   https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
+    "\n",
+    "   \n"
    ]
   },
   {
@@ -39,7 +41,7 @@
    "source": [
     "# Create Elastic Cloud deployment\n",
     "\n",
-    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?fromURI=%2Fhome) for a free trial.\n",
     "\n",
     "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
     "   - Under **Advanced settings**, go to **Machine Learning instances**\n",
@@ -437,7 +439,8 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.11.4 64-bit",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -450,7 +453,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/search/04-multilingual.ipynb
+++ b/notebooks/search/04-multilingual.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "- Python 3.6 or later\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "- The [Elastic Python client](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/installation.html)\n"
    ]
   },

--- a/notebooks/search/04-multilingual.ipynb
+++ b/notebooks/search/04-multilingual.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "- Python 3.6 or later\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
-    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page))\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n",
     "- The [Elastic Python client](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/installation.html)\n"
    ]
   },
@@ -50,7 +50,7 @@
    "source": [
     "## Create Elastic Cloud deployment\n",
     "\n",
-    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
     "\n",
     "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
     "   - Select **Create deployment**"
@@ -535,7 +535,8 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.11.4 64-bit",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -548,7 +549,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,

--- a/supporting-blog-content/multilingual-e5/multilingual-e5.ipynb
+++ b/supporting-blog-content/multilingual-e5/multilingual-e5.ipynb
@@ -26,7 +26,7 @@
         "For this example, you will need:\n",
         "\n",
         "- An Elastic Cloud deployment with an ML node (min. 8 GB memory)\n",
-        "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n"
+        "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n"
       ]
     },
     {
@@ -464,7 +464,8 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "Python 3.11.4 64-bit",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
@@ -477,7 +478,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.6"
+      "version": "3.11.4"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+      }
     }
   },
   "nbformat": 4,

--- a/supporting-blog-content/multilingual-e5/multilingual-e5.ipynb
+++ b/supporting-blog-content/multilingual-e5/multilingual-e5.ipynb
@@ -26,7 +26,7 @@
         "For this example, you will need:\n",
         "\n",
         "- An Elastic Cloud deployment with an ML node (min. 8 GB memory)\n",
-        "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page))\n"
+        "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook?elektra=en-ess-sign-up-page))\n"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "source": [
         "## Create Elastic Cloud deployment\n",
         "\n",
-        "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?fromURI=%2Fhome) for a free trial.\n",
+        "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial.\n",
         "\n",
         "- Go to the [Create deployment](https://cloud.elastic.co/deployments/create) page\n",
         "   - Select **Create deployment**\n",

--- a/supporting-blog-content/openai-rag-streamlit/openai_rag_streamlit.ipynb
+++ b/supporting-blog-content/openai-rag-streamlit/openai_rag_streamlit.ipynb
@@ -78,7 +78,7 @@
         "## Connect to Elasticsearch\n",
         "\n",
         "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook.\n",
-        "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?fromURI=%2Fhome).\n",
+        "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook).\n",
         "\n",
         "To connect to Elasticsearch, you need to create a client instance with the Cloud ID and password for your deployment.\n",
         "\n",


### PR DESCRIPTION
* Update existing Elastic cloud sign up url with `utm_source` and `utm_content`
* Add trackable sign up link if signup link was not there 
* Update Elasticsearch-labs openai cookbook with trackable url `utm_content=openai-cookbook`