### PR TITLE
Replace rank_features for sparse_vector field type in ELSER examples

### DIFF
--- a/notebooks/langchain/langchain-vector-store-using-elser.ipynb
+++ b/notebooks/langchain/langchain-vector-store-using-elser.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "This workbook demonstrates similiarity search using [SparseVectorRetrievalStrategy](https://api.python.langchain.com/en/latest/vectorstores/langchain.vectorstores.elasticsearch.SparseRetrievalStrategy.html#langchain.vectorstores.elasticsearch.SparseRetrievalStrategy) (ELSER). First,  we  split the documents into chunks using `langchain` and then index into elasticsearch through [`ElasticsearchStore.from_documents`](https://api.python.langchain.com/en/latest/vectorstores/langchain.vectorstores.elasticsearch.ElasticsearchStore.html#langchain.vectorstores.elasticsearch.ElasticsearchStore.from_documents). \n",
     "\n",
-    "The [SparseVectorRetrievalStrategy](https://api.python.langchain.com/en/latest/vectorstores/langchain.vectorstores.elasticsearch.SparseRetrievalStrategy.html#langchain.vectorstores.elasticsearch.SparseRetrievalStrategy) converts each document into tokens and would be stored in `vector` field with datatype `rank_features`. Hence, the inference is handled within elasticsearch.\n",
+    "The [SparseVectorRetrievalStrategy](https://api.python.langchain.com/en/latest/vectorstores/langchain.vectorstores.elasticsearch.SparseRetrievalStrategy.html#langchain.vectorstores.elasticsearch.SparseRetrievalStrategy) converts each document into tokens and would be stored in `vector` field with datatype `sparse_vector`. Hence, the inference is handled within elasticsearch.\n",
     "\n",
     "The `similarity_search` performs semantic search using `text_expansion` and sets the query.\n",
     "\n",

--- a/notebooks/search/03-ELSER.ipynb
+++ b/notebooks/search/03-ELSER.ipynb
@@ -284,7 +284,7 @@
     "## Create index with mappings\n",
     "\n",
     "To use the ELSER model at index time, we'll need to create an index mapping that supports a [`text_expansion`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html) query.\n",
-    "The mapping must include a field of type [`rank_features`](https://www.elastic.co/guide/en/elasticsearch/reference/current/rank-features.html) to work with our feature vectors of interest.\n",
+    "The mapping must include a field of type [`sparse_vector`](https://www.elastic.co/guide/en/elasticsearch/reference/current/rank-features.html) to work with our feature vectors of interest.\n",
     "This field contains the token-weight pairs the ELSER model created based on the input text.\n",
     "\n",
     "Let's create an index named `elser-movies` with the mappings we need.\n"
@@ -323,7 +323,7 @@
     "        }\n",
     "      },\n",
     "      \"ml.tokens\": {\n",
-    "        \"type\": \"rank_features\"\n",
+    "        \"type\": \"sparse_vector\"\n",
     "      },\n",
     "    }\n",
     "  }\n",

--- a/supporting-blog-content/lexical-and-semantic-search-with-elasticsearch/ecommerce_dense_sparse_project.ipynb
+++ b/supporting-blog-content/lexical-and-semantic-search-with-elasticsearch/ecommerce_dense_sparse_project.ipynb
@@ -215,7 +215,7 @@
         "\n",
         "Then, we create a source index to load `products-ecommerce.json`, this will be the `ecommerce` index and a destination index to extract the documents from the source and index these documents into the destination `ecommerce-search`.\n",
         "\n",
-        "For the `ecommerce-search` index we add a field to support dense vector storage and search `description_vector.predicted_value`, this is the target field for inference results. The field type in this case is `dense_vector`, the `all-mpnet-base-v2` model has embedding_size of 768, so dims is set to 768. We also add a `rank_features` field type to support the text expansion output."
+        "For the `ecommerce-search` index we add a field to support dense vector storage and search `description_vector.predicted_value`, this is the target field for inference results. The field type in this case is `dense_vector`, the `all-mpnet-base-v2` model has embedding_size of 768, so dims is set to 768. We also add a `sparse_vector` field type to support the text expansion output."
       ],
       "metadata": {
         "id": "QUQ1nCaiKIQr"
@@ -323,7 +323,7 @@
         "        }\n",
         "      },\n",
         "      \"ml.tokens\": { # The name of the field to contain the generated tokens.\n",
-        "        \"type\": \"rank_features\" # ELSER output must be ingested into a field with the rank_features field type.\n",
+        "        \"type\": \"sparse_vector\" # ELSER output must be ingested into a field with the sparse_vector field type.\n",
         "      },\n",
         "     \"description_vector.predicted_value\": { # Inference results field, target_field.predicted_value\n",
         "     \"type\": \"dense_vector\",\n",


### PR DESCRIPTION
Now that `sparse_vector` [has been re-introduced](https://github.com/elastic/elasticsearch/issues/98104), we should change [Elastic labs notebooks](https://github.com/elastic/elasticsearch-labs) to change references to `rank_features` to `sparse_vector`
