### PR TITLE
Fix dataset url in markdown

### DIFF
--- a/notebooks/search/00-quick-start.ipynb
+++ b/notebooks/search/00-quick-start.ipynb
@@ -239,7 +239,7 @@
       "source": [
         "### Index test data\n",
         "\n",
-        "Run the following command to upload some test data, containing information about 10 popular programming books from this [dataset](https://raw.githubusercontent.com/elastic/elasticsearch-labs/blob/main/notebooks/search/data.json).\n",
+        "Run the following command to upload some test data, containing information about 10 popular programming books from this [dataset](https://raw.githubusercontent.com/elastic/elasticsearch-labs/main/notebooks/search/data.json).\n",
         "`model.encode` will encode the text into a vector on the fly, using the model we initialized earlier."
       ]
     },


### PR DESCRIPTION
I missed this in pr #55.
I also modified the url correctly in markdown.