### PR TITLE
ignore duplicate passages in chatbot frontend

### DIFF
--- a/example-apps/chatbot-rag-app/frontend/src/store/provider.tsx
+++ b/example-apps/chatbot-rag-app/frontend/src/store/provider.tsx
@@ -43,7 +43,9 @@ const globalSlice = createSlice({
       const rootSource = state.sources.find((s) => s.name === source.name)
 
       if (rootSource) {
-        rootSource.summary = [...rootSource.summary, source.summary]
+        if (!rootSource.summary.find((summary) => summary === source.summary)) {
+          rootSource.summary = [...rootSource.summary, source.summary]
+        }
       } else {
         state.sources.push({ ...source, summary: [source.summary] })
       }


### PR DESCRIPTION
In the chatbot app, the frontend sometimes show duplicate passages under a source document. This happens, for example, when a follow-up question is asked, and this question brings up a passage that was also retrieved for the original question. With this change, duplicate passages received by the frontend are ignore.