### PR TITLE
Stop trying to install multiprocessing in notebook

### DIFF
--- a/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
+++ b/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "# install packages\n",
-    "!python3 -m pip install -qU sentence-transformers eland elasticsearch transformers multiprocessing\n",
+    "!python3 -m pip install -qU sentence-transformers eland elasticsearch transformers\n",
     "\n",
     "# import modules\n",
     "import pandas as pd, json\n",


### PR DESCRIPTION
While multiprocessing exists on PyPI, it's a backport of a standard library module for Python 2 that was last updated in 2009. More importantly, it fails to install on Colab.