### PR TITLE
Add a secrets scanner to CI and pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+- repo: https://github.com/sirwart/ripsecrets
+  rev: v0.1.7  # Use latest tag on GitHub
+  hooks:
+  - id: ripsecrets
+    args:
+    # OpenAI keys
+    - --additional-pattern
+    - '(?:sk-)[0-9a-zA-Z_-]{48}'
+    # generic [...]_API_KEY=[...] pattern
+    - --additional-pattern
+    - '_API_KEY=[0-9a-zA-Z_-]{10}'
+    # generic [...]_PASSWORD=[...] pattern
+    - --additional-pattern
+    - '_PASSWORD=[0-9a-zA-Z_-]{10}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,21 @@ Prior to opening a pull request, please:
 - Create an issue to [discuss the scope of your proposal](https://github.com/elastic/elasticsearch-labs/issues). We are happy to provide guidance to make for a pleasant contribution experience.
 - Sign the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 
+### Pre-commit hook
+
+This repository has a pre-commit hook that ensures that your contributed code follows our guidelines. It is strongly recommended that you install the pre-commit hook on your locally cloned repository, as that will allow you to check the correctness of your submission without having to wait for our continuous integration build. To install the pre-commit hook, clone this repository and then run the following command from its top-level directory:
+
+```bash
+make pre-commit
+```
+
+If you do not have access to the `make` utility, you can also install the pre-commit hook with Python:
+
+```bash
+python -m venv .venv
+.venv/bin/pre-commit install
+```
+
 ## General instruction
 
 - If the notebook or code sample requires signing up a Elastic cloud instance, make sure to add appropriate `utm_source` and `utm_content` in the cloud registration url. For example, the Elastic cloud sign up url for the Python notebooks should have `utm_source=github&utm_content=elasticsearch-labs-notebook` and code examples should have `utm_source=github&utm_content=elasticsearch-labs-samples`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: test nbtest notebooks
+.PHONY: pre-commit test nbtest notebooks
+
+pre-commit:
+	python -m venv .venv
+	.venv/bin/pip install -r requirements-dev.txt
+	.venv/bin/pre-commit install
+
+all: test
 
 test: nbtest notebooks
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+cfgv==3.4.0
+distlib==0.3.8
+filelock==3.13.1
+identify==2.5.33
+nodeenv==1.8.0
+platformdirs==4.1.0
+pre-commit==3.6.0
+PyYAML==6.0.1
+setuptools==69.0.3
+virtualenv==20.25.0


### PR DESCRIPTION
This installs the [ripsecrets](https://github.com/sirwart/ripsecrets) utility as a pre-commit hook in this repository. People can install the hook locally by running:

```bash
pip install pre-commit
pre-commit install
```

And then their commits will be scanned for secrets automatically.

The pre-commit hook is also added to GitHub actions to run on PRs.