### PR TITLE
Update requirements.txt

### DIFF
--- a/example-apps/relevance-workbench/app-api/requirements.txt
+++ b/example-apps/relevance-workbench/app-api/requirements.txt
@@ -1,5 +1,6 @@
 flask==2.2.2
 requests==2.28.1
+Werkzeug==2.2.2
 flask-session
 memcache
 elasticsearch


### PR DESCRIPTION
Werkzeug has been updated and the 3.0.0 version doesn't work properly with flask 2.2.2 and won't compile. Specifically stating the Werkzeug version in requirements.txt fixed it.

Without Werkzeug==2.2.2 in requirements.txt

Attaching to api-1, client-1
api-1     | Traceback (most recent call last):
api-1     |   File "/usr/local/lib/python3.9/runpy.py", line 188, in _run_module_as_main
api-1     |     mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
api-1     |   File "/usr/local/lib/python3.9/runpy.py", line 147, in _get_module_details
api-1     |     return _get_module_details(pkg_main_name, error)
api-1     |   File "/usr/local/lib/python3.9/runpy.py", line 111, in _get_module_details
api-1     |     __import__(pkg_name)
api-1     |   File "/usr/local/lib/python3.9/site-packages/flask/__init__.py", line 5, in <module>
api-1     |     from .app import Flask as Flask
api-1     |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 30, in <module>
api-1     |     from werkzeug.urls import url_quote
api-1     | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py)

With Werkzeug==2.2.2, the problem is fixed.