### PR TITLE
Chatbot improvements

### DIFF
--- a/example-apps/chatbot-rag-app/api/templates/rag_prompt.txt
+++ b/example-apps/chatbot-rag-app/api/templates/rag_prompt.txt
@@ -1,4 +1,4 @@
-Use the following passages to answer the user's question. 
+Use the following passages and chat history to answer the user's question. 
 Each passage has a NAME which is the title of the document. After your answer, leave a blank line and then give the source name of the passages you answered from. Put them in a comma separated list, prefixed with SOURCES:.
 
 Example:
@@ -22,5 +22,10 @@ PASSAGE:
 
 {% endfor -%}
 ----
+Chat history:
+{% for dialogue_turn in chat_history -%}
+{% if dialogue_turn.type == 'human' %}Question: {{ dialogue_turn.content }}{% elif dialogue_turn.type == 'ai' %}Response: {{ dialogue_turn.content }}{% endif %}
+{% endfor -%}
+
 Question: {{ question }}
 Response:

--- a/example-apps/chatbot-rag-app/data/index_data.py
+++ b/example-apps/chatbot-rag-app/data/index_data.py
@@ -91,6 +91,9 @@ def main():
         es_connection=elasticsearch_client,
         index_name=INDEX,
         strategy=ElasticsearchStore.SparseVectorRetrievalStrategy(model_id=ELSER_MODEL),
+        bulk_kwargs={
+            'request_timeout': 60,
+        },
     )
 
 

--- a/example-apps/chatbot-rag-app/frontend/src/store/provider.tsx
+++ b/example-apps/chatbot-rag-app/frontend/src/store/provider.tsx
@@ -238,7 +238,7 @@ export const thunkActions = {
               dispatch(
                 actions.updateMessage({
                   id: conversationId,
-                  content: message.replace(/SOURCES: (.+)+/, ''),
+                  content: message.replace(/SOURCES:(.+)*/, ''),
                 })
               )
             }
@@ -300,8 +300,8 @@ const parseSources = (
   message: string
 ) => {
   message = message.replaceAll("\"", "");
-  const match = message.match(/SOURCES: (.+)+/)
-  if (match) {
+  const match = message.match(/SOURCES:(.+)*/)
+  if (match && match[1]) {
     return match[1].split(',').map(element => {
       return element.trim();
     });


### PR DESCRIPTION
This PR includes a set of minor improvements and tunings to the RAG chatbot example:

- The condensed question is used only to retrieve relevant documents from the ES index. Then the LLM receives the original chat history and question from the user with this context. This prevents user questions from diluting as more follow up questions are entered.
- A longer request timeout was added to the bulk importer, for robustness.
- The source parser used in the frontend was expanded to handle a common case in which the LLM does not select any sources from the provided context.