### PR TITLE
Added modal status check, delete index before creating index

### DIFF
--- a/notebooks/document-chunking/with-index-pipelines.ipynb
+++ b/notebooks/document-chunking/with-index-pipelines.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "f38e0397",
    "metadata": {
     "colab": {
@@ -80,16 +80,7 @@
     "id": "f38e0397",
     "outputId": "ad6df489-d242-4229-a42a-39c5ca19d124"
    },
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Elastic Cloud ID:  ········\n",
-      "Elastic Api Key:  ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from elasticsearch import Elasticsearch\n",
     "from getpass import getpass\n",
@@ -170,7 +161,16 @@
     "    --hub-model-id \"sentence-transformers/all-MiniLM-L6-v2\" \\\n",
     "    --task-type text_embedding \\\n",
     "    --clear-previous \\\n",
-    "    --start"
+    "    --start\n",
+    "\n",
+    "while True:\n",
+    "    status = client.ml.get_trained_models_stats(model_id=MODEL_ID)\n",
+    "    if \"trained_model_stats\" in status.keys() and status[\"trained_model_stats\"][0][\"deployment_stats\"][\"state\"] == \"started\":\n",
+    "        print(MODEL_ID + \" Model has been successfully deployed & started.\")\n",
+    "        break\n",
+    "    else:\n",
+    "        print(MODEL_ID + \" Model is currently being deployed.\")\n",
+    "    time.sleep(5)\n"
    ]
   },
   {
@@ -299,6 +299,8 @@
    ],
    "source": [
     "INDEX_NAME = \"chunk_passages_example\"\n",
+    "\n",
+    "client.indices.delete(index=INDEX_NAME, ignore_unavailable=True)\n",
     "\n",
     "# Setup the index\n",
     "client.indices.create(\n",


### PR DESCRIPTION
Found as part of [8.13 Search labs QA ticket](https://github.com/elastic/enterprise-search-team/issues/6957) 

Tests were failing, as it takes a while for modal to be started with Eland tool. Added modal status check similar to ELSER v2 modal check. 
Also add delete index step before creating index. 