### PR TITLE
Adds ES version requirements to inference notebooks

### DIFF
--- a/notebooks/integrations/cohere/inference-cohere.ipynb
+++ b/notebooks/integrations/cohere/inference-cohere.ipynb
@@ -27,6 +27,8 @@
     "\n",
     "- An Elastic deployment with minimum **4GB machine learning node**\n",
     "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
+    "\n",
+    "- Elasticsearch 8.13 or above.\n",
     "   \n",
     "- A paid [Cohere account](https://cohere.com/) is required to use the Inference API with\n",
     "the Cohere service as the Cohere free trial API usage is limited."

--- a/notebooks/search/07-inference.ipynb
+++ b/notebooks/search/07-inference.ipynb
@@ -24,6 +24,8 @@
     "\n",
     "- An Elastic deployment:\n",
     "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
+    "\n",
+    "- Elasticsearch 8.12 or above.\n",
     "   \n",
     "- A paid [OpenAI account](https://openai.com/) is required to use the Inference API with \n",
     "the OpenAI service as the OpenAI free trial API usage is limited. "


### PR DESCRIPTION
## Overview

Closes https://github.com/elastic/elasticsearch-labs/issues/208

This PR adds ES version requirements to the inference API-related notebooks (OpenAI and Cohere).