### PR TITLE
Pin eland to 8.12.1 to avoid build failures

### DIFF
--- a/notebooks/document-chunking/with-index-pipelines.ipynb
+++ b/notebooks/document-chunking/with-index-pipelines.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "!python3 -m pip install -qU elasticsearch eland"
+    "!python3 -m pip install -qU elasticsearch eland==8.12.1"
    ]
   },
   {

--- a/notebooks/document-chunking/with-langchain-splitters.ipynb
+++ b/notebooks/document-chunking/with-langchain-splitters.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m pip install -qU langchain langchain-elasticsearch elasticsearch eland jq"
+    "!python3 -m pip install -qU langchain langchain-elasticsearch elasticsearch eland==8.12.1 jq"
    ]
   },
   {

--- a/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
+++ b/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "!python3 -m pip install sentence-transformers eland elasticsearch transformers"
+    "!python3 -m pip install sentence-transformers eland==8.12.1 elasticsearch transformers"
    ]
   },
   {
@@ -339,21 +339,6 @@
       "\n",
       "['Keeping up with Kibana: This week in Kibana for November 29th, 2019']\n",
       "Score: 0.35690257\n",
-      "\n",
-      "['How to implement similarity image search | Elastic.co | Elastic Blog']\n",
-      "Score: 0.34473613\n",
-      "\n",
-      "['Kibana 4 Video Tutorials, Part 3']\n",
-      "Score: 0.34193927\n",
-      "\n",
-      "['Introducing approximate nearest neighbor search in Elasticsearch 8.0 | Elastic Blog']\n",
-      "Score: 0.3372936\n",
-      "\n",
-      "['Where in the World is Elastic? - QCon Beijing, Devoxx France, Percona Live & AWS Summit Chicago']\n",
-      "Score: 0.33645985\n",
-      "\n",
-      "['EQL for the masses']\n",
-      "Score: 0.3207562\n",
       "\n"
      ]
     }
@@ -365,7 +350,7 @@
     "\n",
     "query = {\n",
     "    \"field\": \"text_embedding.predicted_value\",\n",
-    "    \"k\": 10,\n",
+    "    \"k\": 5,\n",
     "    \"num_candidates\": 50,\n",
     "    \"query_vector_builder\": {\n",
     "        \"text_embedding\": {\n",

--- a/notebooks/langchain/langchain-using-own-model.ipynb
+++ b/notebooks/langchain/langchain-using-own-model.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m pip install -qU langchain langchain-elasticsearch tiktoken  sentence-transformers eland  transformers\n",
+    "!python3 -m pip install -qU langchain langchain-elasticsearch tiktoken  sentence-transformers eland==8.12.1 transformers\n",
     "\n",
     "from getpass import getpass\n",
     "from langchain_elasticsearch import ElasticsearchStore\n",


### PR DESCRIPTION
We are putting a temporary pin on eland==8.12, since eland 8.13 does not work with stacks older than 8.13.

While testing this change I discovered a very minor difference in the results of a kNN request with k=10 between 8.14-SNAPSHOT and the older stacks. I was able to avoid this difference by lowering to k=5.