### PR TITLE
Fix Colab URL to App Search Export Notebook

### DIFF
--- a/notebooks/enterprise-search/app-search-engine-exporter.ipynb
+++ b/notebooks/enterprise-search/app-search-engine-exporter.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# App Search Engine exporter to Elasticsearch\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/enterprise-search/app-search-engine-exporter.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/enterprise-search/app-search-engine-exporter.ipynb)\n",
     "\n",
     "This notebook explains the steps of exporting an App Search engine together with its configurations in Elasticsearch. This is not meant to be an exhaustive example for all App Search features as those will vary based on your instance, but is meant to give a sense of how you can export, migrate, and enhance your application.\n",
     "\n",


### PR DESCRIPTION
I missed the additional `/integrations/` path in the URL for the Colab notebook. This removes it (and has been tested to be correct with this PR)
