### PR TITLE
Fixes the search step of the inference and cohere notebooks

### DIFF
--- a/notebooks/integrations/cohere/inference-cohere.ipynb
+++ b/notebooks/integrations/cohere/inference-cohere.ipynb
@@ -184,6 +184,7 @@
     "id": "96788aa1"
    },
    "source": [
+    "<a name=\"create-the-inference-endpoint\"></a>\n",
     "## Create the inference endpoint\n",
     "\n",
     "Let's create the inference endpoint by using the [Create inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-inference-api.html).\n",
@@ -369,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "a47cdc60",
    "metadata": {
     "colab": {
@@ -406,7 +407,7 @@
     "        \"field\": \"plot_embedding\",\n",
     "        \"query_vector_builder\": {\n",
     "            \"text_embedding\": {\n",
-    "                \"inference_id\": \"cohere_embeddings\",\n",
+    "                \"model_id\": \"cohere_embeddings\",\n",
     "                \"model_text\": \"Fighting movie\",\n",
     "            }\n",
     "        },\n",
@@ -421,6 +422,14 @@
     "    title = hit[\"_source\"][\"title\"]\n",
     "    plot = hit[\"_source\"][\"plot\"]\n",
     "    print(f\"Score: {score}\\nTitle: {title}\\nPlot: {plot}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a38763",
+   "metadata": {},
+   "source": [
+    "**NOTE:** The value of `model_id` in the `query_vector_builder` must match the value of `inference_id` you created in the [first step](#create-the-inference-endpoint)."
    ]
   }
  ],

--- a/notebooks/search/07-inference.ipynb
+++ b/notebooks/search/07-inference.ipynb
@@ -154,6 +154,7 @@
    "id": "840d92f0",
    "metadata": {},
    "source": [
+    "<a name=\"create-the-inference-endpoint\"></a>\n",
     "## Create the inference endpoint\n",
     "\n",
     "Let's create the inference endpoint by using the [Create inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-inference-api.html).\n",
@@ -356,7 +357,7 @@
     "        \"field\": \"plot_embedding\",\n",
     "        \"query_vector_builder\": {\n",
     "            \"text_embedding\": {\n",
-    "                \"inference_id\": \"my_openai_embedding_model\",\n",
+    "                \"model_id\": \"my_openai_embedding_model\",\n",
     "                \"model_text\": \"Fighting movie\",\n",
     "            }\n",
     "        },\n",
@@ -378,14 +379,8 @@
    "id": "7e4055ba",
    "metadata": {},
    "source": [
-    "**NOTE:** If you use Elasticsearch 8.12, you must change `inference_id` in the snippet above to `model_id`."
+    "**NOTE:** The value of `model_id` in the `query_vector_builder` must match the value of `inference_id` you created in the [first step](#create-the-inference-endpoint)."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "59220b82",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Overview

Fixes https://github.com/elastic/elasticsearch-labs/issues/220.

This PR modifies the `query_vector_builder` object properties in the inference and the Cohere notebooks search step. The `query_vector_builder` does not accept `inference_id` only `model_id` at the moment.