### PR TITLE
Fix pip command

### DIFF
--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -193,7 +193,7 @@ python -m venv .venv
 source .venv/bin/activate
 
 # Install Python dependencies
-pip install -r api/requirements.txt
+pip install -r requirements.txt
 
 # Install Node dependencies
 cd frontend && yarn && cd ..


### PR DESCRIPTION
Fix the target of the `pip install` command, since `requirements.txt` is in the root.

Tested manually:
```sh
  ~/workspace/chatbot-rag-app                                                                                              ✘ INT  chatbot-rag-app  14:25:16
❯ pip install -r requirements.txt

Collecting aiohttp==3.8.5 (from -r requirements.txt (line 7))
  Downloading aiohttp-3.8.5-cp311-cp311-macosx_11_0_arm64.whl.metadata (7.7 kB)
Collecting aiosignal==1.3.1 (from -r requirements.txt (line 13))
  Downloading aiosignal-1.3.1-py3-none-any.whl.metadata (4.0 kB)
...
```