### PR TITLE
Stop using perform_request in search tutorial

### DIFF
--- a/example-apps/search-tutorial/v3/search-tutorial/search.py
+++ b/example-apps/search-tutorial/v3/search-tutorial/search.py
@@ -70,15 +70,13 @@ class Search:
 
     def search(self, **query_args):
         # sub_searches is not currently supported in the client, so we send
-        # search requests as raw requests
+        # search requests using the body argument
         if "from_" in query_args:
             query_args["from"] = query_args["from_"]
             del query_args["from_"]
-        return self.es.perform_request(
-            "GET",
-            f"/my_documents/_search",
+        return self.es.search(
+            index="my_documents",
             body=json.dumps(query_args),
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
 
     def retrieve_document(self, id):


### PR DESCRIPTION
Since [elasticsearch-py 8.12.0](https://github.com/elastic/elasticsearch-py/releases/tag/v8.12.0) released earlier this year, using the body parameter is the recommended way to perform requests with unknown parameters like `sub_searches`.

I went through the whole tutorial, everything still works.