### PR TITLE
Show pip dependencies after CI run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,6 @@ jobs:
         run: sleep 30 && PATCH_ES=1 ELASTIC_CLOUD_ID=foo ELASTIC_API_KEY=bar bin/nbtest notebooks/search/00-quick-start.ipynb
       - name: Run tests
         run: PATCH_ES=1 FORCE_COLOR=1 make -s test
+      - name: Show installed Python dependencies
+        if: always()
+        run: .venv/bin/pip freeze


### PR DESCRIPTION
This adds a final task to the CI that shows the output of `pip freeze` to help in debugging issues.