### PR TITLE
CI: remove warmup phase

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,5 @@ jobs:
           python-version: '3.10'
       - name: Setup nbtest
         run: make install-nbtest
-      - name: Warm up
-        continue-on-error: true
-        run: sleep 30 && PATCH_ES=1 ELASTIC_CLOUD_ID=foo ELASTIC_API_KEY=bar bin/nbtest notebooks/search/00-quick-start.ipynb
       - name: Run tests
         run: PATCH_ES=1 FORCE_COLOR=1 make -s test


### PR DESCRIPTION
I don't remember clearly, but I have a feeling that we fixed an issue that we originally intended to solve with the warmup phase.

In this PR, we run CI without warmup X amount of times to show that things also work without it. This gives removes 2.5 to 5 minutes from the CI runs.