### PR TITLE
Update URL Link

### DIFF
--- a/supporting-blog-content/introducing-retrievers/retrievers_intro_notebook.ipynb
+++ b/supporting-blog-content/introducing-retrievers/retrievers_intro_notebook.ipynb
@@ -27,7 +27,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "This notebook allows you to run the exampls from the [Search Labs blog - Introducing Retrievers -  Search All the Things!](https://www.elastic.co/search-labs/blog/introducing-retrievers)\n",
+    "This notebook allows you to run the exampls from the [Search Labs blog - Introducing Retrievers -  Search All the Things!](https://www.elastic.co/search-labs/blog/elasticsearch-retrievers)\n",
     "\n",
     "In this notebook you will:\n",
     "- Download IMDB dataset from Kaggle\n",


### PR DESCRIPTION
Seems that there is an errata on the URL blog address. Should be https://www.elastic.co/search-labs/blog/elasticsearch-retrievers instead of https://www.elastic.co/search-labs/blog/introducing-retrievers (which leads to a 404)