### PR TITLE
pin sentence-transformers to 2.7.0 as 3.0.0 is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ install-pre-commit:
 
 install-nbtest:
 	python3 -m venv $(VENV)
-	$(VENV)/bin/pip install -qqq elastic-nbtest
+	$(VENV)/bin/pip install -qqq elastic-nbtest sentence-transformers==2.7.0

--- a/example-apps/search-tutorial/v2/search-tutorial/requirements.in
+++ b/example-apps/search-tutorial/v2/search-tutorial/requirements.in
@@ -2,4 +2,4 @@ pip-tools
 flask
 python-dotenv
 elasticsearch
-sentence-transformers
+sentence-transformers==2.7.0

--- a/notebooks/images/image-similarity.ipynb
+++ b/notebooks/images/image-similarity.ipynb
@@ -45,7 +45,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install sentence-transformers eland elasticsearch transformers torch tqdm Pillow streamlit"
+    "!pip install sentence-transformers==2.7.0 eland elasticsearch transformers torch tqdm Pillow streamlit"
    ]
   },
   {

--- a/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
+++ b/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "!python3 -m pip install sentence-transformers eland elasticsearch transformers"
+    "!python3 -m pip install sentence-transformers==2.7.0 eland elasticsearch transformers"
    ]
   },
   {

--- a/notebooks/langchain/langchain-using-own-model.ipynb
+++ b/notebooks/langchain/langchain-using-own-model.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m pip install -qU langchain langchain-elasticsearch tiktoken  sentence-transformers eland transformers\n",
+    "!python3 -m pip install -qU langchain langchain-elasticsearch tiktoken  sentence-transformers==2.7.0 eland transformers\n",
     "\n",
     "from getpass import getpass\n",
     "from langchain_elasticsearch import ElasticsearchStore\n",

--- a/notebooks/model-upgrades/_nbtest.setup.upgrading-index-to-use-elser.ipynb
+++ b/notebooks/model-upgrades/_nbtest.setup.upgrading-index-to-use-elser.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch sentence-transformers"
+    "!pip install -qU elasticsearch sentence-transformers==2.7.0"
    ]
   },
   {
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Elastic Cloud ID:  ········\n",

--- a/notebooks/search/00-quick-start.ipynb
+++ b/notebooks/search/00-quick-start.ipynb
@@ -53,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch sentence-transformers"
+    "!pip install -qU elasticsearch sentence-transformers==2.7.0"
    ]
   },
   {

--- a/notebooks/search/02-hybrid-search.ipynb
+++ b/notebooks/search/02-hybrid-search.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch sentence_transformers"
+    "!pip install -qU elasticsearch sentence-transformers==2.7.0"
    ]
   },
   {

--- a/notebooks/search/04-multilingual.ipynb
+++ b/notebooks/search/04-multilingual.ipynb
@@ -82,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch sentence_transformers"
+    "!pip install -qU elasticsearch sentence-transformers==2.7.0"
    ]
   },
   {

--- a/notebooks/search/_nbtest.setup.ipynb
+++ b/notebooks/search/_nbtest.setup.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch sentence-transformers"
+    "!pip install -qU elasticsearch sentence-transformers==2.7.0"
    ]
   },
   {

--- a/supporting-blog-content/vector-search-implementation-guide-api/vector_search_implementation_guide_api.ipynb
+++ b/supporting-blog-content/vector-search-implementation-guide-api/vector_search_implementation_guide_api.ipynb
@@ -1,40 +1,25 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# Simplified Vector Search (kNN) Implementation Guide\n"
-   ],
    "metadata": {
     "id": "XU4UjiHpYdDT"
-   }
+   },
+   "source": [
+    "# Simplified Vector Search (kNN) Implementation Guide\n"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "5lV5UN90l4YN"
+   },
    "source": [
     "# Loading the Embedding Model\n",
     "Loading embedding model: [sentence-transformers/all-distilroberta-v1](https://huggingface.co/sentence-transformers/all-distilroberta-v1)\n",
     "\n",
     "Loading code borrowed from [elasticsearch-labs](https://www.elastic.co/search-labs) NLP text search [example notebook](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/hugging-face/loading-model-from-hugging-face.ipynb)\n"
-   ],
-   "metadata": {
-    "id": "5lV5UN90l4YN"
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -45,11 +30,16 @@
    "outputs": [],
    "source": [
     "# install packages\n",
-    "!pip install -qU eland elasticsearch transformers sentence-transformers torch==1.13"
+    "!pip install -qU eland elasticsearch transformers sentence-transformers==2.7.0 torch==1.13"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Riwvd3CHO9qU"
+   },
+   "outputs": [],
    "source": [
     "# import modules\n",
     "import pandas as pd, json\n",
@@ -58,15 +48,15 @@
     "from getpass import getpass\n",
     "from urllib.request import urlopen\n",
     "from pprint import pprint"
-   ],
-   "metadata": {
-    "id": "Riwvd3CHO9qU"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "So9bJJDVNzgF"
+   },
+   "outputs": [],
    "source": [
     "API_KEY = getpass(\"Elastic deployment API Key\")\n",
     "CLOUD_ID = getpass(\"Elastic deployment Cloud ID\")\n",
@@ -76,35 +66,55 @@
     "\n",
     "es = Elasticsearch(cloud_id=CLOUD_ID, api_key=API_KEY)\n",
     "es.info()  # should return cluster info"
-   ],
-   "metadata": {
-    "id": "So9bJJDVNzgF"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "!eland_import_hub_model --cloud-id $CLOUD_ID --hub-model-id $HUB_MODEL_ID --task-type text_embedding --es-api-key $API_KEY --start"
-   ],
+   "execution_count": null,
    "metadata": {
     "id": "dsFsmzZwpujb"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "!eland_import_hub_model --cloud-id $CLOUD_ID --hub-model-id $HUB_MODEL_ID --task-type text_embedding --es-api-key $API_KEY --start"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "# Ingest pipeline setup"
-   ],
    "metadata": {
     "id": "71wNrH0vl4zi"
-   }
+   },
+   "source": [
+    "# Ingest pipeline setup"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "SL47BJNyl3-r",
+    "outputId": "43588d08-9dfb-4b13-9c42-58e071cf3526"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'acknowledged': True}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-8-5c7708b710af>:44: DeprecationWarning: The 'body' parameter is deprecated and will be removed in a future version. Instead use individual parameters.\n",
+      "  response = es.ingest.put_pipeline(id=pipeline_id, body=pipeline)\n"
+     ]
+    }
+   ],
    "source": [
     "pipeline = {\n",
     "    \"processors\": [\n",
@@ -146,44 +156,44 @@
     "\n",
     "# Print the response\n",
     "print(response)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
-    "id": "SL47BJNyl3-r",
+    "id": "TgBeEw_Ql5I5"
+   },
+   "source": [
+    "# Index Mapping / Template setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
-    "outputId": "43588d08-9dfb-4b13-9c42-58e071cf3526"
+    "id": "zNqjEiPZl36N",
+    "outputId": "55130ac4-042f-4d65-bc4b-08c6527d85d4"
    },
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "{'acknowledged': True}\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "<ipython-input-8-5c7708b710af>:44: DeprecationWarning: The 'body' parameter is deprecated and will be removed in a future version. Instead use individual parameters.\n",
-      "  response = es.ingest.put_pipeline(id=pipeline_id, body=pipeline)\n"
+      "<ipython-input-11-40e8294e4183>:34: ElasticsearchWarning: Legacy index templates are deprecated in favor of composable templates.\n",
+      "  response = es.indices.put_template(name=\"my_vector_index\",\n"
      ]
     }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "# Index Mapping / Template setup"
    ],
-   "metadata": {
-    "id": "TgBeEw_Ql5I5"
-   }
-  },
-  {
-   "cell_type": "code",
    "source": [
     "index_patterns = [\"my_vector_index-*\"]\n",
     "\n",
@@ -221,55 +231,50 @@
     "\n",
     "# Print the response\n",
     "print(response)"
-   ],
-   "metadata": {
-    "id": "zNqjEiPZl36N",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "55130ac4-042f-4d65-bc4b-08c6527d85d4"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "{'acknowledged': True}\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "<ipython-input-11-40e8294e4183>:34: ElasticsearchWarning: Legacy index templates are deprecated in favor of composable templates.\n",
-      "  response = es.indices.put_template(name=\"my_vector_index\",\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "# Indexing Data\n"
-   ],
    "metadata": {
     "id": "bztQcxbll5cs"
-   }
+   },
+   "source": [
+    "# Indexing Data\n"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "index_name = \"my_vector_index-01\""
-   ],
+   "execution_count": null,
    "metadata": {
     "id": "XbapSs1c-hkd"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "index_name = \"my_vector_index-01\""
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "bSIJ-AngVmUi",
+    "outputId": "49074d6e-1d30-44e1-d565-edac0251eae1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ObjectApiResponse({'_shards': {'total': 2, 'successful': 1, 'failed': 0}})"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data = [\n",
     "    (\"Hey, careful, man, there's a beverage here!\", \"The Dude\"),\n",
@@ -301,48 +306,50 @@
     "\n",
     "# Refresh the index to make sure all data is searchable\n",
     "es.indices.refresh(index=\"my_vector_index-01\")"
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "bSIJ-AngVmUi",
-    "outputId": "49074d6e-1d30-44e1-d565-edac0251eae1"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "ObjectApiResponse({'_shards': {'total': 2, 'successful': 1, 'failed': 0}})"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 14
-    }
    ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "# Querying Data\n"
-   ],
    "metadata": {
     "id": "ENlZ3Ndjl5yl"
-   }
+   },
+   "source": [
+    "# Querying Data\n"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Approximate k-nearest neighbor (kNN)"
-   ],
    "metadata": {
     "id": "Xk4CBDpimfDH"
-   }
+   },
+   "source": [
+    "Approximate k-nearest neighbor (kNN)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "xl76_rM4l3iC",
+    "outputId": "9a796cf1-4beb-4405-91b9-c323db756d36"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 0.78170115,\n",
+      "  '_source': {'ml': {'inference': {}},\n",
+      "              'my_metadata': 'The Dude',\n",
+      "              'my_text': \"Hey, careful, man, there's a beverage here!\"}}]\n"
+     ]
+    }
+   ],
    "source": [
     "knn = {\n",
     "    \"field\": \"my_vector\",\n",
@@ -359,41 +366,49 @@
     "response = es.search(index=index_name, knn=knn, source=True)\n",
     "\n",
     "pprint(response[\"hits\"][\"hits\"])"
-   ],
-   "metadata": {
-    "id": "xl76_rM4l3iC",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "9a796cf1-4beb-4405-91b9-c323db756d36"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[{'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 0.78170115,\n",
-      "  '_source': {'ml': {'inference': {}},\n",
-      "              'my_metadata': 'The Dude',\n",
-      "              'my_text': \"Hey, careful, man, there's a beverage here!\"}}]\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Hybrid Searching (kNN + BM25) with RRF"
-   ],
    "metadata": {
     "id": "vhefCRd-mjk8"
-   }
+   },
+   "source": [
+    "## Hybrid Searching (kNN + BM25) with RRF"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "wLY8Q6tEmk06",
+    "outputId": "dc4dd649-3a66-4084-cba1-2e0e51984037"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'_id': 'U-5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 1.8080788,\n",
+      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
+      "             'my_text': ['What do you mean brought it bowling, Dude?']}},\n",
+      " {'_id': 'VO5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 1.2358729,\n",
+      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
+      "             'my_text': ['Donny was a good bowler, and a good man. He was one '\n",
+      "                         'of us. He was a man who loved the outdoors... and '\n",
+      "                         'bowling, and as a surfer he explored the beaches of '\n",
+      "                         'Southern California, from La Jolla to Leo Carrillo '\n",
+      "                         'and... up to... Pismo']}}]\n"
+     ]
+    }
+   ],
    "source": [
     "query = {\"match\": {\"my_text\": \"bowling\"}}\n",
     "\n",
@@ -419,49 +434,40 @@
     ")\n",
     "\n",
     "pprint(response[\"hits\"][\"hits\"])"
-   ],
-   "metadata": {
-    "id": "wLY8Q6tEmk06",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "dc4dd649-3a66-4084-cba1-2e0e51984037"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[{'_id': 'U-5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 1.8080788,\n",
-      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
-      "             'my_text': ['What do you mean brought it bowling, Dude?']}},\n",
-      " {'_id': 'VO5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 1.2358729,\n",
-      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
-      "             'my_text': ['Donny was a good bowler, and a good man. He was one '\n",
-      "                         'of us. He was a man who loved the outdoors... and '\n",
-      "                         'bowling, and as a surfer he explored the beaches of '\n",
-      "                         'Southern California, from La Jolla to Leo Carrillo '\n",
-      "                         'and... up to... Pismo']}}]\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Filtering"
-   ],
    "metadata": {
     "id": "HDBHn_kamlIL"
-   }
+   },
+   "source": [
+    "## Filtering"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yVDMHuM3mla7",
+    "outputId": "ebd848da-8ecc-4683-cb81-719f5a12f815"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 0.59285694,\n",
+      "  'fields': {'my_metadata': ['The Dude'],\n",
+      "             'my_text': [\"Hey, careful, man, there's a beverage here!\"]}}]\n"
+     ]
+    }
+   ],
    "source": [
     "knn = {\n",
     "    \"field\": \"my_vector\",\n",
@@ -481,41 +487,46 @@
     "response = es.search(index=index_name, fields=fields, knn=knn, source=False)\n",
     "\n",
     "pprint(response[\"hits\"][\"hits\"])"
-   ],
-   "metadata": {
-    "id": "yVDMHuM3mla7",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "ebd848da-8ecc-4683-cb81-719f5a12f815"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[{'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 0.59285694,\n",
-      "  'fields': {'my_metadata': ['The Dude'],\n",
-      "             'my_text': [\"Hey, careful, man, there's a beverage here!\"]}}]\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "N_Msyv4-m5ow"
+   },
    "source": [
     "# Aggregrations\n",
     "and Select fields returned"
-   ],
-   "metadata": {
-    "id": "N_Msyv4-m5ow"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jbwinE0fm5-I",
+    "outputId": "e8b02f4b-8a89-417f-a892-2e676a812a2d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'_id': 'U-5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 0.74352247,\n",
+      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
+      "             'my_text': ['What do you mean brought it bowling, Dude?']}},\n",
+      " {'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
+      "  '_index': 'my_vector_index-01',\n",
+      "  '_score': 0.6010935,\n",
+      "  'fields': {'my_metadata': ['The Dude'],\n",
+      "             'my_text': [\"Hey, careful, man, there's a beverage here!\"]}}]\n"
+     ]
+    }
+   ],
    "source": [
     "knn = {\n",
     "    \"field\": \"my_vector\",\n",
@@ -536,33 +547,22 @@
     "response = es.search(index=index_name, fields=fields, aggs=aggs, knn=knn, source=False)\n",
     "\n",
     "pprint(response[\"hits\"][\"hits\"])"
-   ],
-   "metadata": {
-    "id": "jbwinE0fm5-I",
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "outputId": "e8b02f4b-8a89-417f-a892-2e676a812a2d"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[{'_id': 'U-5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 0.74352247,\n",
-      "  'fields': {'my_metadata': ['Walter Sobchak'],\n",
-      "             'my_text': ['What do you mean brought it bowling, Dude?']}},\n",
-      " {'_id': 'UO5Y3IoB3ljSe18vZY6D',\n",
-      "  '_index': 'my_vector_index-01',\n",
-      "  '_score': 0.6010935,\n",
-      "  'fields': {'my_metadata': ['The Dude'],\n",
-      "             'my_text': [\"Hey, careful, man, there's a beverage here!\"]}}]\n"
-     ]
-    }
    ]
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Updated Makefile and notebooks to use `sentence-transformers==2.7.0` since `3.0.0` was released and is currently broken