### PR TITLE
[DOCS] Fixes inference ID in Cohere-ES notebook

### DIFF
--- a/notebooks/integrations/cohere/cohere-elasticsearch.ipynb
+++ b/notebooks/integrations/cohere/cohere-elasticsearch.ipynb
@@ -164,7 +164,7 @@
    "source": [
     "client.inference.put_model(\n",
     "    task_type=\"text_embedding\",\n",
-    "    inference_id=\"cohere_embeddings1\",\n",
+    "    inference_id=\"cohere_embeddings\",\n",
     "    body={\n",
     "        \"service\": \"cohere\",\n",
     "        \"service_settings\": {\n",


### PR DESCRIPTION
## Overview

Closes https://github.com/elastic/elasticsearch-labs/issues/275.

This PR fixes the inference ID in the Cohere-ES notebook.