### PR TITLE
Update client calls to query rules

### DIFF
--- a/notebooks/search/05-query-rules.ipynb
+++ b/notebooks/search/05-query-rules.ipynb
@@ -399,7 +399,7 @@
     }
    ],
    "source": [
-    "client.query_ruleset.put(\n",
+    "client.query_rules.put_ruleset(\n",
     "    ruleset_id=\"promotion-rules\",\n",
     "    rules=[\n",
     "        {\n",
@@ -474,7 +474,7 @@
     }
    ],
    "source": [
-    "response = client.query_ruleset.get(ruleset_id=\"promotion-rules\")\n",
+    "response = client.query_rules.get_ruleset(ruleset_id=\"promotion-rules\")\n",
     "pretty_ruleset(response)"
    ]
   },
@@ -674,7 +674,7 @@
     }
    ],
    "source": [
-    "client.query_ruleset.put(\n",
+    "client.query_rules.put_ruleset(\n",
     "    ruleset_id=\"promotion-rules\",\n",
     "    rules=[\n",
     "        {\n",
@@ -821,7 +821,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Elasticsearch client specification was recently upgraded to support additional query rules CRUD API endpoints. This PR fixes the client calls in this notebook so they work with the updated client. 