### PR TITLE
Add support for semantic search with the dense vector

### DIFF
--- a/example-apps/chatbot-rag-app/api/chat.py
+++ b/example-apps/chatbot-rag-app/api/chat.py
@@ -1,4 +1,4 @@
-from langchain_elasticsearch import ElasticsearchStore, SparseVectorStrategy
+from langchain_elasticsearch import ElasticsearchStore, DenseVectorStrategy, SparseVectorStrategy
 from llm_integrations import get_llm
 from elasticsearch_client import (
     elasticsearch_client,
@@ -12,16 +12,33 @@ INDEX = os.getenv("ES_INDEX", "workplace-app-docs")
 INDEX_CHAT_HISTORY = os.getenv(
     "ES_INDEX_CHAT_HISTORY", "workplace-app-docs-chat-history"
 )
-ELSER_MODEL = os.getenv("ELSER_MODEL", ".elser_model_2")
+MODEL_ID = os.getenv("ES_MODEL_ID", ".elser_model_2")
+STRATEGY_TYPE = os.getenv("ES_STRATEGY_TYPE", "sparse")
+VECTOR_FIELD = os.getenv("ES_VECTOR_FIELD", "vector")
+QUERY_FIELD = os.getenv("ES_QUERY_FIELD", "text")
+
 SESSION_ID_TAG = "[SESSION_ID]"
 SOURCE_TAG = "[SOURCE]"
 DONE_TAG = "[DONE]"
 
-store = ElasticsearchStore(
-    es_connection=elasticsearch_client,
-    index_name=INDEX,
-    strategy=SparseVectorStrategy(model_id=ELSER_MODEL),
-)
+if STRATEGY_TYPE == "sparse":
+    strategy = SparseVectorStrategy(model_id=MODEL_ID)
+    store = ElasticsearchStore(
+        es_connection=elasticsearch_client,
+        index_name=INDEX,
+        strategy=strategy,
+    )
+elif STRATEGY_TYPE == "dense":
+    strategy = DenseVectorStrategy(model_id=MODEL_ID, hybrid=True)
+    store = ElasticsearchStore(
+        es_connection=elasticsearch_client,
+        index_name=INDEX,
+        vector_query_field=VECTOR_FIELD,
+        query_field=QUERY_FIELD,
+        strategy=strategy,
+    )
+else:
+    raise ValueError(f"Invalid strategy type: {STRATEGY_TYPE}")
 
 
 @stream_with_context
@@ -50,9 +67,10 @@ def ask_question(question, session_id):
     docs = store.as_retriever().invoke(condensed_question)
     for doc in docs:
         doc_source = {**doc.metadata, "page_content": doc.page_content}
-        current_app.logger.debug(
-            "Retrieved document passage from: %s", doc.metadata["name"]
-        )
+        if "name" in doc.metadata:
+            current_app.logger.debug(
+                "Retrieved document passage from: %s", doc.metadata["name"]
+            )
         yield f"data: {SOURCE_TAG} {json.dumps(doc_source)}\n\n"
 
     qa_prompt = render_template(

--- a/example-apps/chatbot-rag-app/env.example
+++ b/example-apps/chatbot-rag-app/env.example
@@ -11,6 +11,15 @@ ELASTIC_API_KEY=
 ES_INDEX=workplace-app-docs
 ES_INDEX_CHAT_HISTORY=workplace-app-docs-chat-history
 
+# For sparse vector (e.g. ELSER)
+ES_STRATEGY_TYPE=sparse
+ES_MODEL_ID=.elser_model_2
+# For dense vector (e.g. E5)
+# ES_STRATEGY_TYPE=dense
+# ES_MODEL_ID=.multilingual-e5-small_linux-x86_64
+# ES_VECTOR_FIELD=text_semantic.inference.chunks.embeddings
+# ES_QUERY_FIELD=text
+
 # Uncomment and complete if you want to use OpenAI
 # LLM_TYPE=openai
 # OPENAI_API_KEY=


### PR DESCRIPTION
# Intention

Current chatbot-rag-app only supports SparseVectorStrategy. So I'd like to add DenseVectorStrategy. Especially for the user who wants to use it with non-English speakers, DenseVectorStrategy with E5 models is good option.

# Changes

This pull request introduces several enhancements to the `example-apps/chatbot-rag-app` to support both sparse and dense vector strategies for Elasticsearch. The changes include updates to the environment configuration, the main chat API, and logging improvements.

Support for multiple vector strategies:

* [`example-apps/chatbot-rag-app/api/chat.py`](diffhunk://#diff-da377303e1afe08be252efc24c8c4b570adf8c4cf6567b35bb782bfe35bec706L1-R1): Added support for `DenseVectorStrategy` alongside the existing `SparseVectorStrategy`. Introduced new environment variables to configure the strategy type, model ID, vector field, and query field. [[1]](diffhunk://#diff-da377303e1afe08be252efc24c8c4b570adf8c4cf6567b35bb782bfe35bec706L1-R1) [[2]](diffhunk://#diff-da377303e1afe08be252efc24c8c4b570adf8c4cf6567b35bb782bfe35bec706L15-R41)

Environment configuration updates:

* [`example-apps/chatbot-rag-app/env.example`](diffhunk://#diff-dee43fbe5b6c558ea75ad973e84c6b3041eba6fbff1425c31631ee637e09c18fR14-R22): Updated the example environment file to include configurations for both sparse and dense vector strategies, allowing users to easily switch between them.

Logging improvements:

* [`example-apps/chatbot-rag-app/api/chat.py`](diffhunk://#diff-da377303e1afe08be252efc24c8c4b570adf8c4cf6567b35bb782bfe35bec706R70): Improved logging in the `ask_question` function to ensure that document metadata is logged only if the "name" field is present.