### PR TITLE
openai-embeddings: enable logs, metrics and traces with EDOT Node.js

### DIFF
--- a/example-apps/chatbot-rag-app/docker-compose.yml
+++ b/example-apps/chatbot-rag-app/docker-compose.yml
@@ -5,17 +5,14 @@ services:
     build:
       context: .
     container_name: ingest-data
-    restart: 'no'
+    restart: 'no'  # no need to re-ingest on successive runs
     environment:
-      # host.docker.internal means connect to the host machine, e.g. your laptop
-      ELASTICSEARCH_URL: "http://host.docker.internal:9200"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
       FLASK_APP: api/app.py
     env_file:
       - .env
     command: flask create-index
-    extra_hosts:
-        - "host.docker.internal:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+        - "localhost:host-gateway"
 
   api-frontend:
     depends_on:
@@ -24,13 +21,9 @@ services:
     container_name: api-frontend
     build:
       context: .
-    environment:
-      # host.docker.internal means connect to the host machine, e.g. your laptop
-      ELASTICSEARCH_URL: "http://host.docker.internal:9200"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
     env_file:
       - .env
     ports:
       - "4000:4000"
-    extra_hosts:
-        - "host.docker.internal:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+        - "localhost:host-gateway"

--- a/example-apps/openai-embeddings/Dockerfile
+++ b/example-apps/openai-embeddings/Dockerfile
@@ -8,5 +8,9 @@ RUN --mount=type=cache,target=/root/.npm \
 USER node
 EXPOSE 3000
 
+# Default to disabling instrumentation, can be overridden to false in
+# docker invocations to reenable.
+ENV OTEL_SDK_DISABLED=true
+
 ENTRYPOINT ["npm", "run"]
 CMD ["app"]

--- a/example-apps/openai-embeddings/README.md
+++ b/example-apps/openai-embeddings/README.md
@@ -109,6 +109,22 @@ npm run app
 Here are some tips for modifying the code for your use case. For example, you
 might want to use your own sample data.
 
+### OpenTelemetry
+
+If you set `OTEL_SDK_DISABLED=false` in your `.env` file, the app will send
+logs, metrics and traces to an OpenTelemetry compatible endpoint.
+
+[env.example](env.example) defaults to use Elastic APM server, started by
+[docker-compose-elastic.yml](docker-compose-elastic.yml). If you start your
+Elastic stack this way, you can access Kibana like this, authenticating with
+the username "elastic" and password "elastic":
+
+http://localhost:5601/app/apm/traces?rangeFrom=now-15m&rangeTo=now
+
+Under the scenes, openai-embeddings is automatically instrumented by the Elastic
+Distribution of OpenTelemetry (EDOT) Node.js. You can see more details about
+EDOT Node.js [here](https://github.com/elastic/elastic-otel-node).
+
 ### Using a different source file or document mapping
 
 - Ensure your file contains the documents in JSON format

--- a/example-apps/openai-embeddings/docker-compose.yml
+++ b/example-apps/openai-embeddings/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       # host.docker.internal means connect to the host machine, e.g. your laptop
       ELASTICSEARCH_URL: "http://host.docker.internal:9200"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
     env_file:
       - .env
     command: generate
@@ -25,6 +26,7 @@ services:
     environment:
       # host.docker.internal means connect to the host machine, e.g. your laptop
       ELASTICSEARCH_URL: "http://host.docker.internal:9200"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
     env_file:
       - .env
     ports:

--- a/example-apps/openai-embeddings/docker-compose.yml
+++ b/example-apps/openai-embeddings/docker-compose.yml
@@ -5,16 +5,12 @@ services:
     build:
       context: .
     container_name: generate
-    restart: 'no'
-    environment:
-      # host.docker.internal means connect to the host machine, e.g. your laptop
-      ELASTICSEARCH_URL: "http://host.docker.internal:9200"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
+    restart: 'no'  # no need to re-ingest on successive runs
     env_file:
       - .env
     command: generate
-    extra_hosts:
-        - "host.docker.internal:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+      - "localhost:host-gateway"
 
   app:
     depends_on:
@@ -23,13 +19,9 @@ services:
     container_name: api-frontend
     build:
       context: .
-    environment:
-      # host.docker.internal means connect to the host machine, e.g. your laptop
-      ELASTICSEARCH_URL: "http://host.docker.internal:9200"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:8200"
     env_file:
       - .env
     ports:
       - "3000:3000"
-    extra_hosts:
-        - "host.docker.internal:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+      - "localhost:host-gateway"

--- a/example-apps/openai-embeddings/env.example
+++ b/example-apps/openai-embeddings/env.example
@@ -14,3 +14,22 @@ OPENAI_API_KEY=
 # OPENAI_BASE_URL=http://localhost:11434/v1
 # OPENAI_API_KEY=unused
 # EMBEDDINGS_MODEL=all-minilm:33m
+
+# Set to false, if you want to record logs, traces and metrics.
+OTEL_SDK_DISABLED=true
+
+# Assign the service name that shows up in Kibana
+OTEL_SERVICE_NAME=chatbot-rag-app
+
+# Default to send traces to the Elastic APM server
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8200
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Export metrics every 3 seconds instead of every minute
+OTEL_METRIC_EXPORT_INTERVAL=3000
+OTEL_METRIC_EXPORT_TIMEOUT=3000
+# Export traces every 3 seconds instead of every 5 seconds
+OTEL_BSP_SCHEDULE_DELAY=3000
+# Change to affect behavior of which resources are detected. Note: these
+# choices are specific to the runtime, in this case Node.js.
+OTEL_NODE_RESOURCE_DETECTORS=container,env,host,os,serviceinstance,process,alibaba,aws,azure

--- a/example-apps/openai-embeddings/package.json
+++ b/example-apps/openai-embeddings/package.json
@@ -7,11 +7,13 @@
     "node": ">=20"
   },
   "scripts": {
-    "app": "node --env-file .env search_app.js",
-    "generate": "node --env-file .env generate_embeddings.js"
+    "app": "node --env-file .env -r @elastic/opentelemetry-node search_app.js",
+    "generate": "node --env-file .env -r @elastic/opentelemetry-node generate_embeddings.js"
   },
   "dependencies": {
+    "@elastic/opentelemetry-node": "*",
     "@elastic/elasticsearch": "^8.17.0",
+    "@opentelemetry/api": "^1.9.0",
     "express": "^4.21.2",
     "hbs": "^4.2.0",
     "openai": "^4.78.1"


### PR DESCRIPTION
This adds instructions for how the user can enable logs, metrics and traces with EDOT Node.js

Notably, this includes setting the .env variable `OTEL_SDK_DISABLED=false`

The elastic stack managed by docker compose in this directory already includes APM server, so following directions results in the following two traces:

generate: one time when the corresponding script is invoked (implicitly with docker compose)
<img width="1259" alt="Screenshot 2025-01-16 at 8 14 41 AM" src="https://github.com/user-attachments/assets/9d505267-0730-4aaf-872d-fa0009ba9b7d" />

GET /search: for each request made to the web app
<img width="1268" alt="Screenshot 2025-01-16 at 8 15 02 AM" src="https://github.com/user-attachments/assets/b6bfa60b-2678-4884-9cba-b5142abc7ba1" />
