### PR TITLE
Use published images in chatbot-rag-app example

### DIFF
--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -57,7 +57,7 @@ Docker compose is the easiest way, as you get one-step to:
 **Double-check you have a `.env` file with all your variables set first!**
 
 ```bash
-docker compose up --force-recreate
+docker compose up --pull always --force-recreate
 ```
 
 *Note*: First time creating the index can fail on timeout. Wait a few minutes

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -51,14 +51,13 @@ ease while locally is advised if you are making changes to the application.
 ### Run with docker
 
 Docker compose is the easiest way, as you get one-step to:
-* build the [frontend](frontend)
 * ingest data into elasticsearch
 * run the app, which listens on http://localhost:4000
 
 **Double-check you have a `.env` file with all your variables set first!**
 
 ```bash
-docker compose up --build --force-recreate
+docker compose up --force-recreate
 ```
 
 *Note*: First time creating the index can fail on timeout. Wait a few minutes
@@ -186,6 +185,14 @@ passages. Modify this script to index your own data.
 
 See [Langchain documentation][loader-docs] for more ways to load documents.
 
+### Building from source with docker
+
+To build the app with Docker instead of using published images, pass the `--build`
+flag to Compose.
+
+```bash
+docker compose up --build --force-recreate
+```
 
 ---
 [loader-docs]: https://python.langchain.com/docs/how_to/#document-loaders

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -187,7 +187,7 @@ See [Langchain documentation][loader-docs] for more ways to load documents.
 
 ### Building from source with docker
 
-To build the app with Docker instead of using published images, pass the `--build`
+To build the app from source instead of using published images, pass the `--build`
 flag to Compose.
 
 ```bash

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -188,7 +188,7 @@ See [Langchain documentation][loader-docs] for more ways to load documents.
 ### Building from source with docker
 
 To build the app from source instead of using published images, pass the `--build`
-flag to Compose.
+flag to Docker Compose.
 
 ```bash
 docker compose up --build --force-recreate

--- a/example-apps/chatbot-rag-app/docker-compose.yml
+++ b/example-apps/chatbot-rag-app/docker-compose.yml
@@ -2,6 +2,7 @@ name: chatbot-rag-app
 
 services:
   ingest-data:
+    image: ghcr.io/elastic/elasticsearch-labs/chatbot-rag-app
     build:
       context: .
     container_name: ingest-data
@@ -22,6 +23,7 @@ services:
       ingest-data:
         condition: service_completed_successfully
     container_name: api-frontend
+    image: ghcr.io/elastic/elasticsearch-labs/chatbot-rag-app
     build:
       context: .
     env_file:


### PR DESCRIPTION
Adds the published image to the chatbot-rag-app docker-compose. It's used by default if `--build` isn't passed.