### PR TITLE
Add CODEOWNERS for projects integrated with OpenTelemetry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# opentelemetry-enabled examples and their dependencies
+.github/workflows/ @codefromthecrypt @anuraaga
+docker/ @codefromthecrypt @anuraaga
+k8s/ @codefromthecrypt @anuraaga
+example-apps/chatbot-rag-app/ @codefromthecrypt @anuraaga
+example-apps/openai-embeddings/ @codefromthecrypt @anuraaga


### PR DESCRIPTION
This adds myself and @anuraaga as CODEOWNERS for recently "opentelemetrized" examples and dependencies to run them. Note the k8s directory will be added in #396. Having us here helps keep things typically done in APAC rollin!