### PR TITLE
chatbot-rag-app: removes unnecessary parts of Docker build

### DIFF
--- a/example-apps/chatbot-rag-app/Dockerfile
+++ b/example-apps/chatbot-rag-app/Dockerfile
@@ -24,13 +24,6 @@ EXPOSE 4000
 # Default to disabling instrumentation, can be overridden to false in
 # docker invocations to reenable.
 ENV OTEL_SDK_DISABLED=true
+ENTRYPOINT [ "opentelemetry-instrument" ]
 
-# TODO remove custom entrypoint when EDOT Python >0.7.0 is released.
-RUN echo 'if [ "${OTEL_SDK_DISABLED:-true}" == "false" ]; \
-  then \
-    opentelemetry-instrument $@; \
-  else \
-    exec $@; \
-  fi' > entrypoint.sh
-ENTRYPOINT [ "bash", "-eu", "./entrypoint.sh" ]
 CMD [ "python", "api/app.py" ]

--- a/example-apps/chatbot-rag-app/k8s-manifest.yml
+++ b/example-apps/chatbot-rag-app/k8s-manifest.yml
@@ -24,7 +24,7 @@ spec:
       initContainers:
         - name: create-index
           image: &image ghcr.io/elastic/elasticsearch-labs/chatbot-rag-app:latest
-          command: &command [ "bash", "-eu", "./entrypoint.sh" ] # match image
+          command: &command [ "opentelemetry-instrument" ] # match image
           args: [ "flask", "create-index" ]
           # This recreates your configmap based on your .env file:
           # kubectl create configmap chatbot-rag-app-env --from-env-file=.env

--- a/example-apps/chatbot-rag-app/requirements.txt
+++ b/example-apps/chatbot-rag-app/requirements.txt
@@ -531,4 +531,4 @@ opentelemetry-instrumentation-sqlalchemy==0.51b0
 opentelemetry-instrumentation-system-metrics==0.51b0
 opentelemetry-instrumentation-tortoiseorm==0.51b0
 opentelemetry-instrumentation-urllib3==0.51b0
-elastic-opentelemetry-instrumentation-openai==0.6.0
+elastic-opentelemetry-instrumentation-openai==0.6.1


### PR DESCRIPTION
This removes the temporary workaround for the OTEL_SDK_DISABLED variable