### PR TITLE
chatbot-rag-app: reduces docker image size

### DIFF
--- a/docker/docker-compose-elastic.yml
+++ b/docker/docker-compose-elastic.yml
@@ -69,7 +69,7 @@ services:
       - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=fhjskloppd678ehkdfdlliverpoolfcr
       - SERVER_PUBLICBASEURL=http://127.0.0.1:5601
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'All services are available'"]
+      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'available'"]
       retries: 300
       interval: 1s
 

--- a/example-apps/chatbot-rag-app/Dockerfile
+++ b/example-apps/chatbot-rag-app/Dockerfile
@@ -5,24 +5,19 @@ COPY frontend ./frontend
 RUN cd frontend && yarn install
 RUN cd frontend && REACT_APP_API_HOST=/api yarn build
 
+# langchain and vertexai depend on a large number of system packages including
+# linux-headers, g++, geos, geos-dev, rust and cargo. These are already present
+# on -slim and adding them to -alpine results in a larger image than -slim.
 FROM python:3.12-slim
 
 WORKDIR /app
 RUN mkdir -p ./frontend/build
 COPY --from=build-step ./app/frontend/build ./frontend/build
-RUN mkdir ./api
-RUN mkdir ./data
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    software-properties-common \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
 
 COPY requirements.txt ./requirements.txt
 RUN pip3 install -r ./requirements.txt
+
+RUN mkdir -p ./api ./data
 COPY api ./api
 COPY data ./data
 

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -165,8 +165,6 @@ pip-compile
 pip install -r requirements.txt
 # Add opentelemetry instrumentation for these dependencies
 edot-bootstrap >> requirements.txt
-# Missing dependency for langtrace vertexai instrumentation
-echo "setuptools" >> requirements.txt
 # Install opentelemetry dependencies
 pip install -r requirements.txt
 ```

--- a/example-apps/chatbot-rag-app/requirements.in
+++ b/example-apps/chatbot-rag-app/requirements.in
@@ -16,5 +16,5 @@ langchain-mistralai
 
 # EDOT dependencies
 elastic-opentelemetry
-# Additional LLM support not in EDOT
+# Additional LLM support not yet in EDOT
 langtrace-python-sdk

--- a/example-apps/chatbot-rag-app/requirements.txt
+++ b/example-apps/chatbot-rag-app/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.12
+aiohttp==3.11.13
     # via
     #   langchain
     #   langchain-community
@@ -22,15 +22,15 @@ attrs==25.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-boto3==1.36.24
+boto3==1.37.0
     # via
     #   langchain-aws
     #   langtrace-python-sdk
-botocore==1.36.24
+botocore==1.37.0
     # via
     #   boto3
     #   s3transfer
-cachetools==5.5.1
+cachetools==5.5.2
     # via google-auth
 certifi==2025.1.31
     # via
@@ -80,7 +80,7 @@ flask==3.1.0
     # via
     #   -r requirements.in
     #   flask-cors
-flask-cors==5.0.0
+flask-cors==5.0.1
     # via -r requirements.in
 frozenlist==1.5.0
     # via
@@ -109,11 +109,11 @@ google-cloud-aiplatform==1.81.0
     # via langchain-google-vertexai
 google-cloud-bigquery==3.29.0
     # via google-cloud-aiplatform
-google-cloud-core==2.4.1
+google-cloud-core==2.4.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-google-cloud-resource-manager==1.14.0
+google-cloud-resource-manager==1.14.1
     # via google-cloud-aiplatform
 google-cloud-storage==2.19.0
     # via
@@ -127,7 +127,7 @@ google-resumable-media==2.7.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos[grpc]==1.67.0
+googleapis-common-protos[grpc]==1.68.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -164,7 +164,7 @@ httpx-sse==0.4.0
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-mistralai
-huggingface-hub==0.29.0
+huggingface-hub==0.29.1
     # via
     #   tokenizers
     #   transformers
@@ -200,7 +200,7 @@ langchain-cohere==0.4.2
     # via -r requirements.in
 langchain-community==0.3.18
     # via langchain-cohere
-langchain-core==0.3.37
+langchain-core==0.3.39
     # via
     #   langchain
     #   langchain-aws
@@ -215,13 +215,13 @@ langchain-elasticsearch==0.3.2
     # via -r requirements.in
 langchain-google-vertexai==2.0.13
     # via -r requirements.in
-langchain-mistralai==0.2.6
+langchain-mistralai==0.2.7
     # via -r requirements.in
-langchain-openai==0.3.6
+langchain-openai==0.3.7
     # via -r requirements.in
 langchain-text-splitters==0.3.6
     # via langchain
-langsmith==0.3.8
+langsmith==0.3.11
     # via
     #   langchain
     #   langchain-community
@@ -250,7 +250,7 @@ numpy==2.2.3
     #   langchain-community
     #   shapely
     #   transformers
-openai==1.63.2
+openai==1.64.0
     # via langchain-openai
 opentelemetry-api==1.30.0
     # via
@@ -323,11 +323,12 @@ packaging==24.2
     #   google-cloud-bigquery
     #   huggingface-hub
     #   langchain-core
+    #   langsmith
     #   marshmallow
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-sqlalchemy
     #   transformers
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -372,7 +373,7 @@ pydantic-core==2.27.2
     # via
     #   cohere
     #   pydantic
-pydantic-settings==2.7.1
+pydantic-settings==2.8.0
     # via langchain-community
 python-dateutil==2.9.0.post0
     # via
@@ -491,7 +492,9 @@ urllib3==2.3.0
     #   sentry-sdk
     #   types-requests
 werkzeug==3.1.3
-    # via flask
+    # via
+    #   flask
+    #   flask-cors
 wrapt==1.17.2
     # via
     #   deprecated
@@ -529,4 +532,3 @@ opentelemetry-instrumentation-system-metrics==0.51b0
 opentelemetry-instrumentation-tortoiseorm==0.51b0
 opentelemetry-instrumentation-urllib3==0.51b0
 elastic-opentelemetry-instrumentation-openai==0.6.0
-setuptools


### PR DESCRIPTION
This reduces the chatbot-rag-app image size from 1.3GB to 820MB by eliminating ancillary packages.

This is more needed when we use k8s which doesn't share an image cache with docker, typically. When demo'ing we want the least download lag possible. Also, my network is not always very strong, so prefer smaller.

While at it, I did a little polishing, too.

Anecdotally, I tried to switch to alpine, but the amount of system packages needed resulted in a larger image than it is now!