### PR TITLE
Adding configuring chunking settings notebook for blog

### DIFF
--- a/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
+++ b/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
@@ -25,7 +25,9 @@
     "- An Elastic deployment:\n",
     "   - We'll be using [Elastic serverless](https://www.elastic.co/docs/current/serverless) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "\n",
-    "- Elasticsearch 8.16 or above."
+    "- Elasticsearch 8.16 or above.\n",
+    "\n",
+    "- Python 3.7 or above."
    ]
   },
   {
@@ -55,24 +57,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8c4b16bc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: elasticsearch in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (8.17.1)\n",
-      "Requirement already satisfied: elastic-transport<9,>=8.15.1 in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elasticsearch) (8.17.0)\n",
-      "Requirement already satisfied: urllib3<3,>=1.26.2 in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elastic-transport<9,>=8.15.1->elasticsearch) (2.3.0)\n",
-      "Requirement already satisfied: certifi in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elastic-transport<9,>=8.15.1->elasticsearch) (2025.1.31)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install elasticsearch"
    ]
@@ -87,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "690ff9af",
    "metadata": {},
    "outputs": [],
@@ -103,19 +91,19 @@
    "source": [
     "Now we can instantiate the Python Elasticsearch client.\n",
     "\n",
-    "First we prompt the user for their password and Cloud ID.\n",
-    "Then we create a `client` object that instantiates an instance of the `Elasticsearch` class."
+    "First provide your API key and Serverless Endpoint.\n",
+    "Then create a `client` object that instantiates an instance of the `Elasticsearch` class."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "195cc597",
    "metadata": {},
    "outputs": [],
    "source": [
     "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#finding-your-cloud-id\n",
-    "ELASTIC_CLOUD_ID = getpass(\"Elastic Cloud ID: \")\n",
+    "ELASTIC_SERVERLESS_ENDPOINT = getpass(\"Elastic serverless endpoint: \")\n",
     "\n",
     "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#creating-an-api-key\n",
     "ELASTIC_API_KEY = getpass(\"Elastic Api Key: \")\n",
@@ -123,8 +111,8 @@
     "# Create the client instance\n",
     "client = Elasticsearch(\n",
     "    # For local development\n",
-    "    #hosts=[\"http://localhost:9200\"],\n",
-    "    cloud_id=ELASTIC_CLOUD_ID,\n",
+    "    # hosts=[\"http://localhost:9200\"],\n",
+    "    hosts=[ELASTIC_SERVERLESS_ENDPOINT],\n",
     "    api_key=ELASTIC_API_KEY,\n",
     "    request_timeout=120,\n",
     "    max_retries=10,\n",
@@ -143,18 +131,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "cc0de5ea",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'name': 'runTask-0', 'cluster_name': 'runTask', 'cluster_uuid': 'P0mSKeG7Qxe0PQszKQUhOA', 'version': {'number': '9.1.0-SNAPSHOT', 'build_flavor': 'default', 'build_type': 'tar', 'build_hash': 'c4dcdee9f8e42987e9d09a667e6b5ebcecc00fa9', 'build_date': '2025-03-03T19:12:08.271285Z', 'build_snapshot': True, 'lucene_version': '10.1.0', 'minimum_wire_compatibility_version': '8.19.0', 'minimum_index_compatibility_version': '8.0.0'}, 'tagline': 'You Know, for Search'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(client.info())"
    ]
@@ -186,38 +166,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0d007737",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ObjectApiResponse({'inference_id': 'my_elser_endpoint', 'task_type': 'sparse_embedding', 'service': 'elasticsearch', 'service_settings': {'num_allocations': 1, 'num_threads': 1, 'model_id': '.elser_model_2'}, 'chunking_settings': {'strategy': 'sentence', 'max_chunk_size': 25, 'sentence_overlap': 1}})"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client.inference.put(\n",
-    "\ttask_type=\"sparse_embedding\",\n",
-    "\tinference_id=\"my_elser_endpoint\",\n",
-    "\tbody={\n",
+    "    task_type=\"sparse_embedding\",\n",
+    "    inference_id=\"my_elser_endpoint\",\n",
+    "    body={\n",
     "        \"service\": \"elasticsearch\",\n",
-    "    \t\t\"service_settings\": {\n",
-    "\t    \"num_allocations\": 1,\n",
-    "\t\t\t\"num_threads\": 1,\n",
-    "\t\t\t\"model_id\": \".elser_model_2\"\n",
-    "  \t\t},\n",
-    "\t\t\"chunking_settings\": {\n",
-    "\t\t\t\"strategy\": \"sentence\",\n",
-    "\t\t\t\"max_chunk_size\": 25,\n",
-    "\t\t\t\"sentence_overlap\": 1\n",
-    "\t\t}\n",
-    "\t}\n",
+    "        \"service_settings\": {\n",
+    "            \"num_allocations\": 1,\n",
+    "            \"num_threads\": 1,\n",
+    "            \"model_id\": \".elser_model_2\",\n",
+    "        },\n",
+    "        \"chunking_settings\": {\n",
+    "            \"strategy\": \"sentence\",\n",
+    "            \"max_chunk_size\": 25,\n",
+    "            \"sentence_overlap\": 1,\n",
+    "        },\n",
+    "    },\n",
     ")"
    ]
   },
@@ -234,32 +203,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "0eed3e3b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ObjectApiResponse({'acknowledged': True, 'shards_acknowledged': True, 'index': 'my_index'})"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client.indices.create(\n",
-    "index=\"my_index\",\n",
-    "mappings={\n",
+    "    index=\"my_index\",\n",
+    "    mappings={\n",
     "        \"properties\": {\n",
-    "                \"infer_field\": {\n",
-    "                        \"type\": \"semantic_text\",\n",
-    "                        \"inference_id\": \"my_elser_endpoint\"\n",
-    "                }\n",
+    "            \"infer_field\": {\n",
+    "                \"type\": \"semantic_text\",\n",
+    "                \"inference_id\": \"my_elser_endpoint\",\n",
+    "            }\n",
     "        }\n",
-    "})"
+    "    },\n",
+    ")"
    ]
   },
   {
@@ -270,30 +229,24 @@
     "<a name=\"ingest-a-document\"></a>\n",
     "## Ingest a document\n",
     "\n",
-    "Now let's ingest a document into the index created in the previous step."
+    "Now let's ingest a document into the index created in the previous step.\n",
+    "\n",
+    "Note: It may take some time Elasticsearch to allocate nodes to the ELSER model deployment that is started when creating the inference endpoint. You will need to wait until the deployment is allocated to a node before the request below can succeed."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "b8ecaec0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ObjectApiResponse({'_index': 'my_index', '_id': '_Fh3XZUBHKE836hZgHKV', '_version': 1, 'result': 'created', '_shards': {'total': 2, 'successful': 1, 'failed': 0}, '_seq_no': 0, '_primary_term': 1})"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "client.index(index=\"my_index\", document={\n",
-    "\t\"infer_field\": \"This is some sample document data. The data is being used to demonstrate the configurable chunking settings feature. The configured chunking settings will determine how this text is broken down into chunks to help increase inference accuracy.\"\n",
-    "})"
+    "client.index(\n",
+    "    index=\"my_index\",\n",
+    "    document={\n",
+    "        \"infer_field\": \"This is some sample document data. The data is being used to demonstrate the configurable chunking settings feature. The configured chunking settings will determine how this text is broken down into chunks to help increase inference accuracy.\"\n",
+    "    },\n",
+    ")"
    ]
   },
   {
@@ -309,29 +262,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "58dc9019",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ObjectApiResponse({'took': 32, 'timed_out': False, '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0}, 'hits': {'total': {'value': 1, 'relation': 'eq'}, 'max_score': 1.0, 'hits': [{'_index': 'my_index', '_id': '_Fh3XZUBHKE836hZgHKV', '_score': 1.0, '_source': {'infer_field': 'This is some sample document data. The data is being used to demonstrate the configurable chunking settings feature. The configured chunking settings will determine how this text is broken down into chunks to help increase inference accuracy.', '_inference_fields': {'infer_field': {'inference': {'inference_id': 'my_elser_endpoint', 'model_settings': {'task_type': 'sparse_embedding'}, 'chunks': {'infer_field': [{'start_offset': 0, 'end_offset': 117, 'embeddings': {'##able': 0.73828125, '##e': 0.011505127, '##fi': 1.0898438, '##gur': 1.2460938, '##ing': 1.1835938, '##u': 0.015289307, 'above': 0.28320312, 'algorithm': 0.5683594, 'apache': 0.5839844, 'api': 0.038208008, 'application': 0.041137695, 'archive': 0.6015625, 'batch': 0.1081543, 'beam': 0.14355469, 'below': 0.48828125, 'block': 0.734375, 'bot': 0.4873047, 'buffer': 0.4326172, 'bug': 0.08178711, 'bulk': 0.48046875, 'button': 0.54296875, 'cad': 0.60546875, 'camera': 0.34375, 'chart': 0.30566406, 'chess': 0.14892578, 'chip': 0.33007812, 'chunk': 2.4375, 'chunks': 0.43164062, 'client': 0.53125, 'cluster': 0.53125, 'code': 0.13867188, 'compression': 0.34179688, 'computer': 0.068359375, 'con': 0.10205078, 'configuration': 1.0742188, 'control': 0.2319336, 'cube': 0.2939453, 'custom': 0.68359375, 'data': 1.5625, 'database': 0.4111328, 'demonstrate': 1.1914062, 'demonstrated': 0.42382812, 'demonstrating': 0.6933594, 'demonstration': 1.1796875, 'deployment': 0.49414062, 'diagram': 0.19482422, 'display': 0.5878906, 'doc': 0.9199219, 'document': 1.7070312, 'documents': 0.59375, 'download': 0.018249512, 'editor': 0.5683594, 'embedded': 0.057006836, 'evidence': 0.36914062, 'example': 0.44628906, 'excel': 0.24121094, 'explain': 0.27148438, 'explore': 0.2578125, 'feature': 1.2734375, 'features': 0.23925781, 'file': 0.80078125, 'font': 0.21777344, 'format': 0.1328125, 'gage': 0.032104492, 'graphic': 0.28320312, 'group': 0.7128906, 'here': 0.084228516, 'html': 0.14013672, 'illustrate': 0.5800781, 'image': 0.7265625, 'implement': 2.0325184e-05, 'index': 0.047607422, 'information': 0.4267578, 'interface': 0.60546875, 'inventory': 0.17578125, 'is': 0.28320312, 'java': 0.5214844, 'keyboard': 0.6953125, 'lane': 0.33496094, 'layer': 0.30566406, 'layout': 0.5722656, 'link': 0.02758789, 'lump': 1.359375, 'machine': 0.11279297, 'maker': 0.0859375, 'management': 0.17919922, 'manager': 0.0625, 'matrix': 0.13232422, 'memory': 0.09814453, 'mini': 0.07470703, 'mode': 0.2163086, 'model': 0.12084961, 'mouse': 0.5488281, 'mp': 0.24267578, 'network': 0.5136719, 'notebook': 0.11816406, 'option': 0.061523438, 'paper': 0.3642578, 'pattern': 0.19042969, 'picture': 0.7636719, 'platform': 0.024169922, 'playback': 0.19335938, 'processing': 0.020080566, 'proof': 0.5019531, 'protocol': 0.5214844, 'prototype': 0.36132812, 'provided': 0.044555664, 'report': 0.11279297, 'rope': 0.671875, 'routing': 0.44726562, 'sample': 1.75, 'samples': 0.9941406, 'scene': 0.049438477, 'script': 0.3046875, 'sequence': 0.067871094, 'serial': 0.16796875, 'server': 0.52734375, 'setting': 1.0390625, 'settings': 1.2578125, 'setup': 0.25390625, 'sheet': 0.2919922, 'show': 0.6386719, 'sid': 0.5234375, 'slice': 0.0012626648, 'software': 0.4921875, 'some': 0.45996094, 'sorting': 0.41992188, 'source': 0.1430664, 'specify': 0.23339844, 'stack': 0.046875, 'storage': 0.16064453, 'stuffing': 0.29101562, 'symbol': 0.1303711, 'tab': 0.107910156, 'table': 0.34570312, 'tam': 0.18554688, 'technique': 0.18554688, 'test': 0.4248047, 'texture': 0.21142578, 'this': 0.640625, 'tool': 0.36914062, 'tray': 0.36523438, 'tutor': 0.27539062, 'used': 0.8652344, 'useful': 0.4404297, 'user': 0.109375, 'version': 0.036987305, 'video': 0.34472656, 'weaving': 0.00071525574, 'web': 0.2133789, 'wheel': 0.084228516, 'wireless': 0.1850586, 'xml': 0.12695312, 'zoom': 0.5175781}}, {'start_offset': 34, 'end_offset': 198, 'embeddings': {'##able': 0.74609375, '##fi': 0.9355469, '##gur': 1.1757812, '##ing': 1.2109375, 'above': 0.2446289, 'algorithm': 0.5449219, 'apache': 0.047851562, 'archive': 0.2685547, 'below': 0.42089844, 'block': 0.57421875, 'bot': 0.5839844, 'break': 0.7480469, 'breakdown': 0.48535156, 'broken': 1.1992188, 'buffer': 0.15478516, 'bug': 0.028442383, 'bulk': 0.20654297, 'button': 0.3984375, 'cad': 0.12109375, 'chart': 0.05505371, 'chess': 0.010040283, 'chunk': 2.3828125, 'chunks': 0.5214844, 'cipher': 0.1508789, 'client': 0.021850586, 'cluster': 0.2578125, 'column': 0.2939453, 'compression': 0.35351562, 'con': 0.27246094, 'configuration': 1.0429688, 'configured': 1.0703125, 'content': 0.28125, 'control': 0.29101562, 'custom': 0.7246094, 'data': 1.4453125, 'database': 0.10888672, 'default': 0.104003906, 'demonstrate': 1.25, 'demonstrated': 0.6015625, 'demonstrating': 0.7167969, 'demonstration': 1.2226562, 'deployment': 0.4013672, 'determine': 0.8066406, 'determined': 0.5175781, 'display': 0.7050781, 'divide': 0.12182617, 'divided': 0.09863281, 'document': 0.43652344, 'down': 0.9199219, 'editor': 0.8261719, 'embedded': 0.16796875, 'error': 0.031982422, 'example': 0.07519531, 'excel': 0.32128906, 'explain': 0.171875, 'explore': 0.09863281, 'feature': 1.2382812, 'features': 0.2607422, 'file': 0.33203125, 'folded': 0.13427734, 'font': 0.53515625, 'format': 0.47460938, 'graphic': 0.26953125, 'group': 0.4609375, 'handling': 0.0423584, 'html': 0.3828125, 'illustrate': 0.6074219, 'implement': 0.19238281, 'information': 0.05029297, 'interface': 0.3125, 'into': 0.7519531, 'java': 0.73046875, 'keyboard': 0.6269531, 'layer': 0.30371094, 'layout': 0.5878906, 'link': 0.16992188, 'links': 0.09448242, 'lump': 1.3828125, 'merge': 0.02545166, 'mode': 0.2211914, 'mouse': 0.09301758, 'mp': 0.057617188, 'network': 0.052978516, 'option': 0.1743164, 'oversee': 0.1743164, 'page': 0.26757812, 'par': 0.002922058, 'pattern': 0.24121094, 'picture': 0.036865234, 'playback': 0.27734375, 'profile': 0.16552734, 'proof': 0.25976562, 'protocol': 0.1015625, 'prototype': 0.016967773, 'provided': 0.084228516, 'read': 0.1508789, 'rope': 0.14746094, 'sample': 0.007843018, 'script': 0.34472656, 'section': 0.21435547, 'select': 0.088378906, 'separate': 0.005493164, 'sequence': 0.004760742, 'serial': 0.021850586, 'server': 0.21142578, 'setting': 0.9980469, 'settings': 1.203125, 'setup': 0.21826172, 'sheet': 0.24609375, 'show': 0.5859375, 'sid': 0.5371094, 'slice': 0.114746094, 'software': 0.18701172, 'sort': 0.20214844, 'specify': 0.06323242, 'spelling': 0.08325195, 'split': 0.5800781, 'syntax': 0.3720703, 'tab': 0.578125, 'table': 0.31835938, 'technique': 0.05456543, 'tempo': 0.036621094, 'test': 0.203125, 'text': 1.3671875, 'texture': 0.119384766, 'this': 0.20507812, 'tool': 0.21972656, 'tutor': 0.045166016, 'used': 0.890625, 'useful': 0.25, 'user': 0.020568848, 'video': 0.11987305, 'web': 0.05065918, 'wheel': 0.087646484, 'will': 0.064208984, 'xml': 0.119140625, 'zoom': 0.2763672}}, {'start_offset': 120, 'end_offset': 242, 'embeddings': {'##cing': 0.001449585, '##ed': 0.04284668, '##imi': 0.27734375, '##ing': 1.1289062, '##s': 0.1484375, 'ability': 0.2446289, 'accuracy': 1.3085938, 'accurate': 0.4892578, 'adjust': 0.09643555, 'advantage': 0.28222656, 'affect': 0.06616211, 'algorithm': 1.0, 'anal': 0.4501953, 'analysis': 0.6347656, 'analyze': 0.2548828, 'archive': 0.040771484, 'ass': 0.42089844, 'assessment': 0.22070312, 'assist': 0.10473633, 'assumption': 0.23632812, 'audio': 0.14013672, 'behavior': 0.2529297, 'best': 0.08129883, 'better': 0.38476562, 'bits': 0.22167969, 'block': 0.7246094, 'blocks': 0.35546875, 'boost': 0.096191406, 'bot': 0.3798828, 'brain': 0.49316406, 'break': 0.62890625, 'breakdown': 0.5390625, 'broken': 1.0820312, 'buffer': 0.29492188, 'bug': 0.32226562, 'bulk': 0.32714844, 'button': 0.2548828, 'cad': 0.20800781, 'chance': 0.1586914, 'chart': 0.25195312, 'checkpoint': 0.040039062, 'chess': 0.4296875, 'chunk': 2.34375, 'chunks': 1.4960938, 'cipher': 0.3359375, 'class': 0.059936523, 'cluster': 0.22265625, 'column': 0.037719727, 'compression': 0.45214844, 'computation': 0.66796875, 'conclusion': 0.4111328, 'conclusions': 0.111083984, 'confidence': 0.3154297, 'configuration': 1.2460938, 'configured': 1.1914062, 'consistency': 0.109375, 'content': 0.48046875, 'control': 0.453125, 'cube': 0.36328125, 'cue': 0.14453125, 'custom': 0.6328125, 'data': 0.3330078, 'decision': 0.12548828, 'default': 0.6328125, 'deployment': 0.023010254, 'determination': 0.043945312, 'determine': 0.7558594, 'determined': 0.61328125, 'disadvantage': 0.09741211, 'display': 0.15771484, 'divide': 0.14404297, 'divided': 0.18554688, 'division': 0.018493652, 'document': 0.6269531, 'down': 0.7988281, 'editor': 0.7285156, 'effect': 0.15966797, 'encoding': 0.17285156, 'enhance': 0.7109375, 'estimation': 0.064208984, 'evidence': 0.044189453, 'exam': 0.41015625, 'excel': 0.13183594, 'extraction': 0.1459961, 'feature': 0.20019531, 'file': 0.23144531, 'font': 0.30273438, 'forensic': 0.20019531, 'format': 0.5214844, 'fragmented': 0.1184082, 'fragments': 0.16064453, 'gage': 0.7128906, 'graphic': 0.056884766, 'group': 0.27929688, 'guess': 0.80078125, 'help': 0.6484375, 'how': 0.055541992, 'html': 0.2919922, 'important': 0.5371094, 'improve': 0.9375, 'increase': 0.58984375, 'index': 0.16748047, 'inference': 1.6914062, 'interface': 0.21484375, 'interpret': 0.21972656, 'interpretation': 0.4736328, 'into': 0.54296875, 'is': 0.030212402, 'java': 0.7636719, 'junk': 0.2211914, 'keyboard': 0.19091797, 'layout': 0.49121094, 'learning': 0.33691406, 'length': 0.040405273, 'limp': 0.21923828, 'log': 0.08886719, 'lump': 1.5078125, 'managed': 0.09448242, 'management': 0.034301758, 'mask': 0.011199951, 'mat': 0.0078125, 'material': 0.06958008, 'math': 0.6074219, 'memory': 0.40820312, 'method': 0.0009403229, 'mode': 0.58203125, 'modification': 0.092285156, 'network': 0.09277344, 'node': 0.13720703, 'notation': 0.10913086, 'notebook': 0.11425781, 'observation': 4.541874e-05, 'optimal': 0.27148438, 'optimization': 0.048583984, 'option': 0.48046875, 'oversee': 0.24072266, 'par': 0.1508789, 'pattern': 0.26953125, 'performance': 0.072753906, 'piece': 0.23291016, 'pieces': 0.5917969, 'platform': 0.044433594, 'plot': 0.40039062, 'practice': 0.026733398, 'precision': 0.8222656, 'predict': 1.1015625, 'preference': 0.2397461, 'preferences': 0.0057678223, 'processing': 0.34570312, 'profile': 0.18554688, 'protocol': 0.23779297, 'quality': 0.17236328, 'read': 0.33496094, 'reading': 0.6074219, 'reduce': 0.18554688, 'regression': 0.41503906, 'regulate': 0.029724121, 'regulation': 0.15478516, 'representation': 0.036865234, 'rope': 0.203125, 'sample': 0.34570312, 'scribe': 0.0234375, 'script': 0.09423828, 'segment': 0.033691406, 'segments': 0.1303711, 'select': 0.4296875, 'selection': 0.12060547, 'separated': 0.017150879, 'sequence': 0.4111328, 'sequencing': 0.006454468, 'server': 0.12841797, 'setting': 1.1015625, 'settings': 1.2460938, 'setup': 0.14746094, 'sha': 0.03869629, 'sharpe': 0.036254883, 'sid': 0.15722656, 'slice': 0.34765625, 'software': 0.4609375, 'sort': 0.16357422, 'spatial': 0.071777344, 'specify': 0.18847656, 'speech': 0.11230469, 'speed': 0.07788086, 'spelling': 0.3125, 'split': 0.5214844, 'string': 0.30664062, 'structure': 0.030029297, 'study': 0.2265625, 'syntax': 0.359375, 'tab': 0.56640625, 'table': 0.3623047, 'technique': 0.4267578, 'tempo': 0.099609375, 'text': 1.5429688, 'texts': 0.084228516, 'texture': 0.14208984, 'thick': 0.11010742, 'this': 0.15820312, 'tool': 0.39941406, 'tree': 0.34960938, 'tutor': 0.25390625, 'useful': 0.6113281, 'will': 0.19580078, 'xml': 0.09643555, 'zoom': 0.14013672}}]}}}}}}]}})"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "client.search(index=\"my_index\", body = {\n",
-    "    \t'size' : 100,\n",
-    "    \t'query': {\n",
-    "        \t'match_all' : {}\n",
-    "    \t},\n",
-    "       'fields': [ '_inference_fields' ]\n",
-    "})"
+    "client.search(\n",
+    "    index=\"my_index\",\n",
+    "    body={\"size\": 100, \"query\": {\"match_all\": {}}, \"fields\": [\"_inference_fields\"]},\n",
+    ")"
    ]
   },
   {
@@ -348,7 +287,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -362,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
+++ b/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a765629",
+   "metadata": {},
+   "source": [
+    "# Configuring Chunking Settings For Inference Endpoints\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb)\n",
+    "\n",
+    "\n",
+    "Learn how to configure [chunking settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html#infer-chunking-config) for [Inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html) endpoints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9101eb9",
+   "metadata": {},
+   "source": [
+    "# 🧰 Requirements\n",
+    "\n",
+    "For this example, you will need:\n",
+    "\n",
+    "- An Elastic deployment:\n",
+    "   - We'll be using [Elastic serverless](https://www.elastic.co/docs/current/serverless) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
+    "\n",
+    "- Elasticsearch 8.16 or above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cd69cc0",
+   "metadata": {},
+   "source": [
+    "# Create Elastic Cloud deployment or serverless project\n",
+    "\n",
+    "If you don't have an Elastic Cloud deployment, sign up [here](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook) for a free trial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f27dffbf",
+   "metadata": {},
+   "source": [
+    "# Install packages and connect with Elasticsearch Client\n",
+    "\n",
+    "To get started, we'll need to connect to our Elastic deployment using the Python client (version 8.12.0 or above).\n",
+    "Because we're using an Elastic Cloud deployment, we'll use the **Cloud ID** to identify our deployment.\n",
+    "\n",
+    "First we need to `pip` install the following packages:\n",
+    "\n",
+    "- `elasticsearch`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8c4b16bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: elasticsearch in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (8.17.1)\n",
+      "Requirement already satisfied: elastic-transport<9,>=8.15.1 in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elasticsearch) (8.17.0)\n",
+      "Requirement already satisfied: urllib3<3,>=1.26.2 in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elastic-transport<9,>=8.15.1->elasticsearch) (2.3.0)\n",
+      "Requirement already satisfied: certifi in /Users/danielrubinstein/.pyenv/versions/3.11.10/lib/python3.11/site-packages (from elastic-transport<9,>=8.15.1->elasticsearch) (2025.1.31)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install elasticsearch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41ef96b3",
+   "metadata": {},
+   "source": [
+    "Next, we need to import the modules we need. 🔐 NOTE: getpass enables us to securely prompt the user for credentials without echoing them to the terminal, or storing it in memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "690ff9af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from elasticsearch import Elasticsearch\n",
+    "from getpass import getpass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23fa2b6c",
+   "metadata": {},
+   "source": [
+    "Now we can instantiate the Python Elasticsearch client.\n",
+    "\n",
+    "First we prompt the user for their password and Cloud ID.\n",
+    "Then we create a `client` object that instantiates an instance of the `Elasticsearch` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "195cc597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#finding-your-cloud-id\n",
+    "ELASTIC_CLOUD_ID = getpass(\"Elastic Cloud ID: \")\n",
+    "\n",
+    "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#creating-an-api-key\n",
+    "ELASTIC_API_KEY = getpass(\"Elastic Api Key: \")\n",
+    "\n",
+    "# Create the client instance\n",
+    "client = Elasticsearch(\n",
+    "    # For local development\n",
+    "    #hosts=[\"http://localhost:9200\"],\n",
+    "    cloud_id=ELASTIC_CLOUD_ID,\n",
+    "    api_key=ELASTIC_API_KEY,\n",
+    "    request_timeout=120,\n",
+    "    max_retries=10,\n",
+    "    retry_on_timeout=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1115ffb",
+   "metadata": {},
+   "source": [
+    "### Test the Client\n",
+    "Before you continue, confirm that the client has connected with this test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cc0de5ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'runTask-0', 'cluster_name': 'runTask', 'cluster_uuid': 'P0mSKeG7Qxe0PQszKQUhOA', 'version': {'number': '9.1.0-SNAPSHOT', 'build_flavor': 'default', 'build_type': 'tar', 'build_hash': 'c4dcdee9f8e42987e9d09a667e6b5ebcecc00fa9', 'build_date': '2025-03-03T19:12:08.271285Z', 'build_snapshot': True, 'lucene_version': '10.1.0', 'minimum_wire_compatibility_version': '8.19.0', 'minimum_index_compatibility_version': '8.0.0'}, 'tagline': 'You Know, for Search'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(client.info())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "659c5890",
+   "metadata": {},
+   "source": [
+    "Refer to [the documentation](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connect-self-managed-new) to learn how to connect to a self-managed deployment.\n",
+    "\n",
+    "Read [this page](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connect-self-managed-new) to learn how to connect using API keys."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "840d92f0",
+   "metadata": {},
+   "source": [
+    "<a name=\"create-the-inference-endpoint\"></a>\n",
+    "## Create the inference endpoint object\n",
+    "\n",
+    "Let's create the inference endpoint by using the [Create Inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-inference-api.html#put-inference-api-desc).\n",
+    "\n",
+    "In this example, you'll be creating an inference endpoint for the [ELSER integration](https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-elser.html) which will deploy Elastic's [ELSER model](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-elser.html) within your cluster. Chunking settings are configurable for any inference endpoint with an embedding task type. A full list of available integrations can be found in the [Create Inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-inference-api.html#put-inference-api-desc) documentation.\n",
+    "\n",
+    "To configure chunking settings, the request body must contain a `chunking_settings` map with a `strategy` value along with any required values for the selected chunking strategy. For this example, you'll be configuring chunking settings for a `sentence` strategy with a maximum chunk size of 25 words and 1 sentence overlap between chunks. For more information on available chunking strategies and their configurable values, see the [chunking strategies documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html#_chunking_strategies)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0d007737",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ObjectApiResponse({'inference_id': 'my_elser_endpoint', 'task_type': 'sparse_embedding', 'service': 'elasticsearch', 'service_settings': {'num_allocations': 1, 'num_threads': 1, 'model_id': '.elser_model_2'}, 'chunking_settings': {'strategy': 'sentence', 'max_chunk_size': 25, 'sentence_overlap': 1}})"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.inference.put(\n",
+    "\ttask_type=\"sparse_embedding\",\n",
+    "\tinference_id=\"my_elser_endpoint\",\n",
+    "\tbody={\n",
+    "        \"service\": \"elasticsearch\",\n",
+    "    \t\t\"service_settings\": {\n",
+    "\t    \"num_allocations\": 1,\n",
+    "\t\t\t\"num_threads\": 1,\n",
+    "\t\t\t\"model_id\": \".elser_model_2\"\n",
+    "  \t\t},\n",
+    "\t\t\"chunking_settings\": {\n",
+    "\t\t\t\"strategy\": \"sentence\",\n",
+    "\t\t\t\"max_chunk_size\": 25,\n",
+    "\t\t\t\"sentence_overlap\": 1\n",
+    "\t\t}\n",
+    "\t}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f01de885",
+   "metadata": {},
+   "source": [
+    "<a name=\"create-the-index\"></a>\n",
+    "## Create the index\n",
+    "\n",
+    "To see the chunking settings you've configured in action, you'll need to ingest a document into a semantic text field of an index. Let's create an index with a semantic text field linked to the inference endpoint created in the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0eed3e3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ObjectApiResponse({'acknowledged': True, 'shards_acknowledged': True, 'index': 'my_index'})"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.indices.create(\n",
+    "index=\"my_index\",\n",
+    "mappings={\n",
+    "        \"properties\": {\n",
+    "                \"infer_field\": {\n",
+    "                        \"type\": \"semantic_text\",\n",
+    "                        \"inference_id\": \"my_elser_endpoint\"\n",
+    "                }\n",
+    "        }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51ae72e4",
+   "metadata": {},
+   "source": [
+    "<a name=\"ingest-a-document\"></a>\n",
+    "## Ingest a document\n",
+    "\n",
+    "Now let's ingest a document into the index created in the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b8ecaec0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ObjectApiResponse({'_index': 'my_index', '_id': '_Fh3XZUBHKE836hZgHKV', '_version': 1, 'result': 'created', '_shards': {'total': 2, 'successful': 1, 'failed': 0}, '_seq_no': 0, '_primary_term': 1})"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.index(index=\"my_index\", document={\n",
+    "\t\"infer_field\": \"This is some sample document data. The data is being used to demonstrate the configurable chunking settings feature. The configured chunking settings will determine how this text is broken down into chunks to help increase inference accuracy.\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccc7ca3a",
+   "metadata": {},
+   "source": [
+    "<a name=\"view-the-chunks\"></a>\n",
+    "## View the chunks\n",
+    "\n",
+    "The generated chunks and their corresponding inference results can be seen stored in the document in the index under the key `chunks` within the `_inference_fields` metafield. The chunks are stored as a list of character offset values. Let's see the chunks generated when ingesting the documenting in the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "58dc9019",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ObjectApiResponse({'took': 32, 'timed_out': False, '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0}, 'hits': {'total': {'value': 1, 'relation': 'eq'}, 'max_score': 1.0, 'hits': [{'_index': 'my_index', '_id': '_Fh3XZUBHKE836hZgHKV', '_score': 1.0, '_source': {'infer_field': 'This is some sample document data. The data is being used to demonstrate the configurable chunking settings feature. The configured chunking settings will determine how this text is broken down into chunks to help increase inference accuracy.', '_inference_fields': {'infer_field': {'inference': {'inference_id': 'my_elser_endpoint', 'model_settings': {'task_type': 'sparse_embedding'}, 'chunks': {'infer_field': [{'start_offset': 0, 'end_offset': 117, 'embeddings': {'##able': 0.73828125, '##e': 0.011505127, '##fi': 1.0898438, '##gur': 1.2460938, '##ing': 1.1835938, '##u': 0.015289307, 'above': 0.28320312, 'algorithm': 0.5683594, 'apache': 0.5839844, 'api': 0.038208008, 'application': 0.041137695, 'archive': 0.6015625, 'batch': 0.1081543, 'beam': 0.14355469, 'below': 0.48828125, 'block': 0.734375, 'bot': 0.4873047, 'buffer': 0.4326172, 'bug': 0.08178711, 'bulk': 0.48046875, 'button': 0.54296875, 'cad': 0.60546875, 'camera': 0.34375, 'chart': 0.30566406, 'chess': 0.14892578, 'chip': 0.33007812, 'chunk': 2.4375, 'chunks': 0.43164062, 'client': 0.53125, 'cluster': 0.53125, 'code': 0.13867188, 'compression': 0.34179688, 'computer': 0.068359375, 'con': 0.10205078, 'configuration': 1.0742188, 'control': 0.2319336, 'cube': 0.2939453, 'custom': 0.68359375, 'data': 1.5625, 'database': 0.4111328, 'demonstrate': 1.1914062, 'demonstrated': 0.42382812, 'demonstrating': 0.6933594, 'demonstration': 1.1796875, 'deployment': 0.49414062, 'diagram': 0.19482422, 'display': 0.5878906, 'doc': 0.9199219, 'document': 1.7070312, 'documents': 0.59375, 'download': 0.018249512, 'editor': 0.5683594, 'embedded': 0.057006836, 'evidence': 0.36914062, 'example': 0.44628906, 'excel': 0.24121094, 'explain': 0.27148438, 'explore': 0.2578125, 'feature': 1.2734375, 'features': 0.23925781, 'file': 0.80078125, 'font': 0.21777344, 'format': 0.1328125, 'gage': 0.032104492, 'graphic': 0.28320312, 'group': 0.7128906, 'here': 0.084228516, 'html': 0.14013672, 'illustrate': 0.5800781, 'image': 0.7265625, 'implement': 2.0325184e-05, 'index': 0.047607422, 'information': 0.4267578, 'interface': 0.60546875, 'inventory': 0.17578125, 'is': 0.28320312, 'java': 0.5214844, 'keyboard': 0.6953125, 'lane': 0.33496094, 'layer': 0.30566406, 'layout': 0.5722656, 'link': 0.02758789, 'lump': 1.359375, 'machine': 0.11279297, 'maker': 0.0859375, 'management': 0.17919922, 'manager': 0.0625, 'matrix': 0.13232422, 'memory': 0.09814453, 'mini': 0.07470703, 'mode': 0.2163086, 'model': 0.12084961, 'mouse': 0.5488281, 'mp': 0.24267578, 'network': 0.5136719, 'notebook': 0.11816406, 'option': 0.061523438, 'paper': 0.3642578, 'pattern': 0.19042969, 'picture': 0.7636719, 'platform': 0.024169922, 'playback': 0.19335938, 'processing': 0.020080566, 'proof': 0.5019531, 'protocol': 0.5214844, 'prototype': 0.36132812, 'provided': 0.044555664, 'report': 0.11279297, 'rope': 0.671875, 'routing': 0.44726562, 'sample': 1.75, 'samples': 0.9941406, 'scene': 0.049438477, 'script': 0.3046875, 'sequence': 0.067871094, 'serial': 0.16796875, 'server': 0.52734375, 'setting': 1.0390625, 'settings': 1.2578125, 'setup': 0.25390625, 'sheet': 0.2919922, 'show': 0.6386719, 'sid': 0.5234375, 'slice': 0.0012626648, 'software': 0.4921875, 'some': 0.45996094, 'sorting': 0.41992188, 'source': 0.1430664, 'specify': 0.23339844, 'stack': 0.046875, 'storage': 0.16064453, 'stuffing': 0.29101562, 'symbol': 0.1303711, 'tab': 0.107910156, 'table': 0.34570312, 'tam': 0.18554688, 'technique': 0.18554688, 'test': 0.4248047, 'texture': 0.21142578, 'this': 0.640625, 'tool': 0.36914062, 'tray': 0.36523438, 'tutor': 0.27539062, 'used': 0.8652344, 'useful': 0.4404297, 'user': 0.109375, 'version': 0.036987305, 'video': 0.34472656, 'weaving': 0.00071525574, 'web': 0.2133789, 'wheel': 0.084228516, 'wireless': 0.1850586, 'xml': 0.12695312, 'zoom': 0.5175781}}, {'start_offset': 34, 'end_offset': 198, 'embeddings': {'##able': 0.74609375, '##fi': 0.9355469, '##gur': 1.1757812, '##ing': 1.2109375, 'above': 0.2446289, 'algorithm': 0.5449219, 'apache': 0.047851562, 'archive': 0.2685547, 'below': 0.42089844, 'block': 0.57421875, 'bot': 0.5839844, 'break': 0.7480469, 'breakdown': 0.48535156, 'broken': 1.1992188, 'buffer': 0.15478516, 'bug': 0.028442383, 'bulk': 0.20654297, 'button': 0.3984375, 'cad': 0.12109375, 'chart': 0.05505371, 'chess': 0.010040283, 'chunk': 2.3828125, 'chunks': 0.5214844, 'cipher': 0.1508789, 'client': 0.021850586, 'cluster': 0.2578125, 'column': 0.2939453, 'compression': 0.35351562, 'con': 0.27246094, 'configuration': 1.0429688, 'configured': 1.0703125, 'content': 0.28125, 'control': 0.29101562, 'custom': 0.7246094, 'data': 1.4453125, 'database': 0.10888672, 'default': 0.104003906, 'demonstrate': 1.25, 'demonstrated': 0.6015625, 'demonstrating': 0.7167969, 'demonstration': 1.2226562, 'deployment': 0.4013672, 'determine': 0.8066406, 'determined': 0.5175781, 'display': 0.7050781, 'divide': 0.12182617, 'divided': 0.09863281, 'document': 0.43652344, 'down': 0.9199219, 'editor': 0.8261719, 'embedded': 0.16796875, 'error': 0.031982422, 'example': 0.07519531, 'excel': 0.32128906, 'explain': 0.171875, 'explore': 0.09863281, 'feature': 1.2382812, 'features': 0.2607422, 'file': 0.33203125, 'folded': 0.13427734, 'font': 0.53515625, 'format': 0.47460938, 'graphic': 0.26953125, 'group': 0.4609375, 'handling': 0.0423584, 'html': 0.3828125, 'illustrate': 0.6074219, 'implement': 0.19238281, 'information': 0.05029297, 'interface': 0.3125, 'into': 0.7519531, 'java': 0.73046875, 'keyboard': 0.6269531, 'layer': 0.30371094, 'layout': 0.5878906, 'link': 0.16992188, 'links': 0.09448242, 'lump': 1.3828125, 'merge': 0.02545166, 'mode': 0.2211914, 'mouse': 0.09301758, 'mp': 0.057617188, 'network': 0.052978516, 'option': 0.1743164, 'oversee': 0.1743164, 'page': 0.26757812, 'par': 0.002922058, 'pattern': 0.24121094, 'picture': 0.036865234, 'playback': 0.27734375, 'profile': 0.16552734, 'proof': 0.25976562, 'protocol': 0.1015625, 'prototype': 0.016967773, 'provided': 0.084228516, 'read': 0.1508789, 'rope': 0.14746094, 'sample': 0.007843018, 'script': 0.34472656, 'section': 0.21435547, 'select': 0.088378906, 'separate': 0.005493164, 'sequence': 0.004760742, 'serial': 0.021850586, 'server': 0.21142578, 'setting': 0.9980469, 'settings': 1.203125, 'setup': 0.21826172, 'sheet': 0.24609375, 'show': 0.5859375, 'sid': 0.5371094, 'slice': 0.114746094, 'software': 0.18701172, 'sort': 0.20214844, 'specify': 0.06323242, 'spelling': 0.08325195, 'split': 0.5800781, 'syntax': 0.3720703, 'tab': 0.578125, 'table': 0.31835938, 'technique': 0.05456543, 'tempo': 0.036621094, 'test': 0.203125, 'text': 1.3671875, 'texture': 0.119384766, 'this': 0.20507812, 'tool': 0.21972656, 'tutor': 0.045166016, 'used': 0.890625, 'useful': 0.25, 'user': 0.020568848, 'video': 0.11987305, 'web': 0.05065918, 'wheel': 0.087646484, 'will': 0.064208984, 'xml': 0.119140625, 'zoom': 0.2763672}}, {'start_offset': 120, 'end_offset': 242, 'embeddings': {'##cing': 0.001449585, '##ed': 0.04284668, '##imi': 0.27734375, '##ing': 1.1289062, '##s': 0.1484375, 'ability': 0.2446289, 'accuracy': 1.3085938, 'accurate': 0.4892578, 'adjust': 0.09643555, 'advantage': 0.28222656, 'affect': 0.06616211, 'algorithm': 1.0, 'anal': 0.4501953, 'analysis': 0.6347656, 'analyze': 0.2548828, 'archive': 0.040771484, 'ass': 0.42089844, 'assessment': 0.22070312, 'assist': 0.10473633, 'assumption': 0.23632812, 'audio': 0.14013672, 'behavior': 0.2529297, 'best': 0.08129883, 'better': 0.38476562, 'bits': 0.22167969, 'block': 0.7246094, 'blocks': 0.35546875, 'boost': 0.096191406, 'bot': 0.3798828, 'brain': 0.49316406, 'break': 0.62890625, 'breakdown': 0.5390625, 'broken': 1.0820312, 'buffer': 0.29492188, 'bug': 0.32226562, 'bulk': 0.32714844, 'button': 0.2548828, 'cad': 0.20800781, 'chance': 0.1586914, 'chart': 0.25195312, 'checkpoint': 0.040039062, 'chess': 0.4296875, 'chunk': 2.34375, 'chunks': 1.4960938, 'cipher': 0.3359375, 'class': 0.059936523, 'cluster': 0.22265625, 'column': 0.037719727, 'compression': 0.45214844, 'computation': 0.66796875, 'conclusion': 0.4111328, 'conclusions': 0.111083984, 'confidence': 0.3154297, 'configuration': 1.2460938, 'configured': 1.1914062, 'consistency': 0.109375, 'content': 0.48046875, 'control': 0.453125, 'cube': 0.36328125, 'cue': 0.14453125, 'custom': 0.6328125, 'data': 0.3330078, 'decision': 0.12548828, 'default': 0.6328125, 'deployment': 0.023010254, 'determination': 0.043945312, 'determine': 0.7558594, 'determined': 0.61328125, 'disadvantage': 0.09741211, 'display': 0.15771484, 'divide': 0.14404297, 'divided': 0.18554688, 'division': 0.018493652, 'document': 0.6269531, 'down': 0.7988281, 'editor': 0.7285156, 'effect': 0.15966797, 'encoding': 0.17285156, 'enhance': 0.7109375, 'estimation': 0.064208984, 'evidence': 0.044189453, 'exam': 0.41015625, 'excel': 0.13183594, 'extraction': 0.1459961, 'feature': 0.20019531, 'file': 0.23144531, 'font': 0.30273438, 'forensic': 0.20019531, 'format': 0.5214844, 'fragmented': 0.1184082, 'fragments': 0.16064453, 'gage': 0.7128906, 'graphic': 0.056884766, 'group': 0.27929688, 'guess': 0.80078125, 'help': 0.6484375, 'how': 0.055541992, 'html': 0.2919922, 'important': 0.5371094, 'improve': 0.9375, 'increase': 0.58984375, 'index': 0.16748047, 'inference': 1.6914062, 'interface': 0.21484375, 'interpret': 0.21972656, 'interpretation': 0.4736328, 'into': 0.54296875, 'is': 0.030212402, 'java': 0.7636719, 'junk': 0.2211914, 'keyboard': 0.19091797, 'layout': 0.49121094, 'learning': 0.33691406, 'length': 0.040405273, 'limp': 0.21923828, 'log': 0.08886719, 'lump': 1.5078125, 'managed': 0.09448242, 'management': 0.034301758, 'mask': 0.011199951, 'mat': 0.0078125, 'material': 0.06958008, 'math': 0.6074219, 'memory': 0.40820312, 'method': 0.0009403229, 'mode': 0.58203125, 'modification': 0.092285156, 'network': 0.09277344, 'node': 0.13720703, 'notation': 0.10913086, 'notebook': 0.11425781, 'observation': 4.541874e-05, 'optimal': 0.27148438, 'optimization': 0.048583984, 'option': 0.48046875, 'oversee': 0.24072266, 'par': 0.1508789, 'pattern': 0.26953125, 'performance': 0.072753906, 'piece': 0.23291016, 'pieces': 0.5917969, 'platform': 0.044433594, 'plot': 0.40039062, 'practice': 0.026733398, 'precision': 0.8222656, 'predict': 1.1015625, 'preference': 0.2397461, 'preferences': 0.0057678223, 'processing': 0.34570312, 'profile': 0.18554688, 'protocol': 0.23779297, 'quality': 0.17236328, 'read': 0.33496094, 'reading': 0.6074219, 'reduce': 0.18554688, 'regression': 0.41503906, 'regulate': 0.029724121, 'regulation': 0.15478516, 'representation': 0.036865234, 'rope': 0.203125, 'sample': 0.34570312, 'scribe': 0.0234375, 'script': 0.09423828, 'segment': 0.033691406, 'segments': 0.1303711, 'select': 0.4296875, 'selection': 0.12060547, 'separated': 0.017150879, 'sequence': 0.4111328, 'sequencing': 0.006454468, 'server': 0.12841797, 'setting': 1.1015625, 'settings': 1.2460938, 'setup': 0.14746094, 'sha': 0.03869629, 'sharpe': 0.036254883, 'sid': 0.15722656, 'slice': 0.34765625, 'software': 0.4609375, 'sort': 0.16357422, 'spatial': 0.071777344, 'specify': 0.18847656, 'speech': 0.11230469, 'speed': 0.07788086, 'spelling': 0.3125, 'split': 0.5214844, 'string': 0.30664062, 'structure': 0.030029297, 'study': 0.2265625, 'syntax': 0.359375, 'tab': 0.56640625, 'table': 0.3623047, 'technique': 0.4267578, 'tempo': 0.099609375, 'text': 1.5429688, 'texts': 0.084228516, 'texture': 0.14208984, 'thick': 0.11010742, 'this': 0.15820312, 'tool': 0.39941406, 'tree': 0.34960938, 'tutor': 0.25390625, 'useful': 0.6113281, 'will': 0.19580078, 'xml': 0.09643555, 'zoom': 0.14013672}}]}}}}}}]}})"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.search(index=\"my_index\", body = {\n",
+    "    \t'size' : 100,\n",
+    "    \t'query': {\n",
+    "        \t'match_all' : {}\n",
+    "    \t},\n",
+    "       'fields': [ '_inference_fields' ]\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "193f5b8d",
+   "metadata": {},
+   "source": [
+    "<a name=\"conclusion\"></a>\n",
+    "## Conclusion\n",
+    "\n",
+    "You've now learned how to configure chunking settings for an inference endpoint! For more infomration about configurable chunking, see the [configuring chunking](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html#infer-chunking-config) documentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
+++ b/notebooks/document-chunking/configuring-chunking-settings-for-inference-endpoints.ipynb
@@ -23,7 +23,7 @@
     "For this example, you will need:\n",
     "\n",
     "- An Elastic deployment:\n",
-    "   - We'll be using [Elastic serverless](https://www.elastic.co/docs/current/serverless) for this example (available with a [free trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
+    "   - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration?onboarding_token=vectorsearch&utm_source=github&utm_content=elasticsearch-labs-notebook))\n",
     "\n",
     "- Elasticsearch 8.16 or above.\n",
     "\n",
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 13,
    "id": "690ff9af",
    "metadata": {},
    "outputs": [],
@@ -91,19 +91,19 @@
    "source": [
     "Now we can instantiate the Python Elasticsearch client.\n",
     "\n",
-    "First provide your API key and Serverless Endpoint.\n",
-    "Then create a `client` object that instantiates an instance of the `Elasticsearch` class."
+    "First we prompt the user for their password and Cloud ID.\n",
+    "Then we create a `client` object that instantiates an instance of the `Elasticsearch` class."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "195cc597",
    "metadata": {},
    "outputs": [],
    "source": [
     "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#finding-your-cloud-id\n",
-    "ELASTIC_SERVERLESS_ENDPOINT = getpass(\"Elastic serverless endpoint: \")\n",
+    "ELASTIC_CLOUD_ID = getpass(\"Elastic Cloud ID: \")\n",
     "\n",
     "# https://www.elastic.co/search-labs/tutorials/install-elasticsearch/elastic-cloud#creating-an-api-key\n",
     "ELASTIC_API_KEY = getpass(\"Elastic Api Key: \")\n",
@@ -112,7 +112,7 @@
     "client = Elasticsearch(\n",
     "    # For local development\n",
     "    # hosts=[\"http://localhost:9200\"],\n",
-    "    hosts=[ELASTIC_SERVERLESS_ENDPOINT],\n",
+    "    cloud_id=ELASTIC_CLOUD_ID,\n",
     "    api_key=ELASTIC_API_KEY,\n",
     "    request_timeout=120,\n",
     "    max_retries=10,\n",
@@ -281,7 +281,7 @@
     "<a name=\"conclusion\"></a>\n",
     "## Conclusion\n",
     "\n",
-    "You've now learned how to configure chunking settings for an inference endpoint! For more infomration about configurable chunking, see the [configuring chunking](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html#infer-chunking-config) documentation."
+    "You've now learned how to configure chunking settings for an inference endpoint! For more information about configurable chunking, see the [configuring chunking](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html#infer-chunking-config) documentation."
    ]
   }
  ],


### PR DESCRIPTION
Adding a notebook for the configuring chunking settings blog I'm currently writing. A draft of the blog can be seen [here](https://docs.google.com/document/d/16hmcfbVBj4cuWO7BNeEEN12m69T2Pjw5KKUhh187g64/edit?tab=t.0).

Note: I've run through the steps with local testing and with a serverless trial account and confirmed that the steps succeeded.