### PR TITLE
chatbot-rag-app: updates to EDOT GA (unpins instrumentation-openai version)

### DIFF
--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -220,6 +220,7 @@ reinstall like this. Once checked in, any commands above will use updates.
 rm -rf .venv requirements.txt
 python3 -m venv .venv
 source .venv/bin/activate
+pip install --upgrade pip
 # Install dev requirements for pip-compile and edot-bootstrap
 pip install pip-tools elastic-opentelemetry
 # Recreate requirements.txt

--- a/example-apps/chatbot-rag-app/api/llm_integrations.py
+++ b/example-apps/chatbot-rag-app/api/llm_integrations.py
@@ -20,7 +20,8 @@ def init_openai_chat(temperature):
 
 
 def init_vertex_chat(temperature):
-    # VertexAI is not yet in EDOT. Use the Langtrace Python SDK instead
+    # opentelemetry-instrumentation-vertexai is included by EDOT, but does not
+    # yet not support streaming. Use the Langtrace Python SDK instead.
     from langtrace_python_sdk.instrumentation import VertexAIInstrumentation
 
     VertexAIInstrumentation().instrument()

--- a/example-apps/chatbot-rag-app/requirements.txt
+++ b/example-apps/chatbot-rag-app/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.14
+aiohttp==3.11.16
     # via langchain-community
 aiosignal==1.3.2
     # via aiohttp
@@ -20,11 +20,11 @@ attrs==25.3.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-boto3==1.37.15
+boto3==1.37.28
     # via
     #   langchain-aws
     #   langtrace-python-sdk
-botocore==1.37.15
+botocore==1.37.28
     # via
     #   boto3
     #   s3transfer
@@ -41,7 +41,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via flask
-cohere==5.14.0
+cohere==5.14.2
     # via langchain-cohere
 colorama==0.4.6
     # via
@@ -60,7 +60,7 @@ distro==1.9.0
     # via openai
 docstring-parser==0.16
     # via google-cloud-aiplatform
-elastic-opentelemetry==0.8.0
+elastic-opentelemetry==1.0.0
     # via -r requirements.in
 elastic-transport==8.17.1
     # via elasticsearch
@@ -84,7 +84,7 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2025.3.0
+fsspec==2025.3.2
     # via
     #   huggingface-hub
     #   langtrace-python-sdk
@@ -103,9 +103,9 @@ google-auth==2.38.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.85.0
+google-cloud-aiplatform==1.87.0
     # via langchain-google-vertexai
-google-cloud-bigquery==3.30.0
+google-cloud-bigquery==3.31.0
     # via google-cloud-aiplatform
 google-cloud-core==2.4.3
     # via
@@ -117,7 +117,7 @@ google-cloud-storage==2.19.0
     # via
     #   google-cloud-aiplatform
     #   langchain-google-vertexai
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
@@ -162,7 +162,7 @@ httpx-sse==0.4.0
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-mistralai
-huggingface-hub==0.29.3
+huggingface-hub==0.30.1
     # via
     #   tokenizers
     #   transformers
@@ -188,17 +188,17 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.3.21
+langchain==0.3.23
     # via
     #   -r requirements.in
     #   langchain-community
-langchain-aws==0.2.16
+langchain-aws==0.2.18
     # via -r requirements.in
 langchain-cohere==0.4.3
     # via -r requirements.in
-langchain-community==0.3.20
+langchain-community==0.3.21
     # via langchain-cohere
-langchain-core==0.3.45
+langchain-core==0.3.51
     # via
     #   langchain
     #   langchain-aws
@@ -211,20 +211,20 @@ langchain-core==0.3.45
     #   langchain-text-splitters
 langchain-elasticsearch==0.3.2
     # via -r requirements.in
-langchain-google-vertexai==2.0.15
+langchain-google-vertexai==2.0.19
     # via -r requirements.in
-langchain-mistralai==0.2.8
+langchain-mistralai==0.2.10
     # via -r requirements.in
-langchain-openai==0.3.9
+langchain-openai==0.3.12
     # via -r requirements.in
-langchain-text-splitters==0.3.7
+langchain-text-splitters==0.3.8
     # via langchain
-langsmith==0.3.17
+langsmith==0.3.24
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
-langtrace-python-sdk==3.8.7
+langtrace-python-sdk==3.8.11
     # via -r requirements.in
 log-symbols==0.0.14
     # via halo
@@ -234,7 +234,7 @@ markupsafe==3.0.2
     #   werkzeug
 marshmallow==3.26.1
     # via dataclasses-json
-multidict==6.2.0
+multidict==6.3.2
     # via
     #   aiohttp
     #   yarl
@@ -247,9 +247,9 @@ numpy==2.2.4
     #   langchain-community
     #   shapely
     #   transformers
-openai==1.66.5
+openai==1.70.0
     # via langchain-openai
-opentelemetry-api==1.31.0
+opentelemetry-api==1.31.1
     # via
     #   elastic-opentelemetry
     #   langtrace-python-sdk
@@ -261,31 +261,31 @@ opentelemetry-api==1.31.0
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.31.0
+opentelemetry-exporter-otlp==1.31.1
     # via elastic-opentelemetry
-opentelemetry-exporter-otlp-proto-common==1.31.0
+opentelemetry-exporter-otlp-proto-common==1.31.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.31.0
+opentelemetry-exporter-otlp-proto-grpc==1.31.1
     # via
     #   langtrace-python-sdk
     #   opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.31.0
+opentelemetry-exporter-otlp-proto-http==1.31.1
     # via
     #   langtrace-python-sdk
     #   opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.52b0
+opentelemetry-instrumentation==0.52b1
     # via
     #   elastic-opentelemetry
     #   langtrace-python-sdk
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-system-metrics
-opentelemetry-instrumentation-sqlalchemy==0.52b0
+opentelemetry-instrumentation-sqlalchemy==0.52b1
     # via langtrace-python-sdk
-opentelemetry-instrumentation-system-metrics==0.52b0
+opentelemetry-instrumentation-system-metrics==0.52b1
     # via elastic-opentelemetry
-opentelemetry-proto==1.31.0
+opentelemetry-proto==1.31.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -294,7 +294,7 @@ opentelemetry-resource-detector-azure==0.1.5
     # via elastic-opentelemetry
 opentelemetry-resourcedetector-gcp==1.8.0a0
     # via elastic-opentelemetry
-opentelemetry-sdk==1.31.0
+opentelemetry-sdk==1.31.1
     # via
     #   elastic-opentelemetry
     #   langtrace-python-sdk
@@ -305,13 +305,13 @@ opentelemetry-sdk==1.31.0
     #   opentelemetry-sdk-extension-aws
 opentelemetry-sdk-extension-aws==2.1.0
     # via elastic-opentelemetry
-opentelemetry-semantic-conventions==0.52b0
+opentelemetry-semantic-conventions==0.52b1
     # via
     #   elastic-opentelemetry
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-orjson==3.10.15
+orjson==3.10.16
     # via langsmith
 packaging==24.2
     # via
@@ -325,7 +325,7 @@ packaging==24.2
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-sqlalchemy
     #   transformers
-propcache==0.3.0
+propcache==0.3.1
     # via
     #   aiohttp
     #   yarl
@@ -334,7 +334,7 @@ proto-plus==1.26.1
     #   google-api-core
     #   google-cloud-aiplatform
     #   google-cloud-resource-manager
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   google-api-core
     #   google-cloud-aiplatform
@@ -350,9 +350,9 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
-pydantic==2.10.6
+pydantic==2.11.2
     # via
     #   cohere
     #   google-cloud-aiplatform
@@ -366,7 +366,7 @@ pydantic==2.10.6
     #   openai
     #   pydantic-settings
     #   trace-attributes
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   cohere
     #   pydantic
@@ -376,7 +376,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   google-cloud-bigquery
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via pydantic-settings
 pyyaml==6.0.2
     # via
@@ -412,9 +412,9 @@ s3transfer==0.11.4
     # via boto3
 safetensors==0.5.3
     # via transformers
-sentry-sdk==2.23.1
+sentry-sdk==2.25.1
     # via langtrace-python-sdk
-shapely==2.0.7
+shapely==2.1.0
     # via google-cloud-aiplatform
 simsimd==6.2.1
     # via elasticsearch
@@ -428,16 +428,16 @@ sniffio==1.3.1
     #   openai
 spinners==0.0.24
     # via halo
-sqlalchemy==2.0.39
+sqlalchemy==2.0.40
     # via
     #   langchain
     #   langchain-community
     #   langtrace-python-sdk
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   langchain-community
     #   langchain-core
-termcolor==2.5.0
+termcolor==3.0.1
     # via halo
 tiktoken==0.9.0
     # via
@@ -454,15 +454,15 @@ tqdm==4.67.1
     #   huggingface-hub
     #   openai
     #   transformers
-trace-attributes==7.2.0
+trace-attributes==7.2.1
     # via langtrace-python-sdk
-transformers==4.49.0
+transformers==4.51.0
     # via langtrace-python-sdk
-types-pyyaml==6.0.12.20241230
+types-pyyaml==6.0.12.20250402
     # via langchain-cohere
-types-requests==2.32.0.20250306
+types-requests==2.32.0.20250328
     # via cohere
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   anyio
     #   cohere
@@ -476,8 +476,11 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   sqlalchemy
     #   typing-inspect
+    #   typing-inspection
 typing-inspect==0.9.0
     # via dataclasses-json
+typing-inspection==0.4.0
+    # via pydantic
 ujson==5.10.0
     # via langtrace-python-sdk
 urllib3==2.3.0
@@ -487,6 +490,8 @@ urllib3==2.3.0
     #   requests
     #   sentry-sdk
     #   types-requests
+validators==0.34.0
+    # via langchain-google-vertexai
 werkzeug==3.1.3
     # via
     #   flask
@@ -496,7 +501,7 @@ wrapt==1.17.2
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-sqlalchemy
-yarl==1.18.3
+yarl==1.19.0
     # via aiohttp
 zipp==3.21.0
     # via importlib-metadata
@@ -505,26 +510,27 @@ zstandard==0.23.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
-opentelemetry-instrumentation-asyncio==0.52b0
-opentelemetry-instrumentation-dbapi==0.52b0
-opentelemetry-instrumentation-logging==0.52b0
-opentelemetry-instrumentation-sqlite3==0.52b0
-opentelemetry-instrumentation-threading==0.52b0
-opentelemetry-instrumentation-urllib==0.52b0
-opentelemetry-instrumentation-wsgi==0.52b0
-opentelemetry-instrumentation-aiohttp-client==0.52b0
-opentelemetry-instrumentation-aiohttp-server==0.52b0
-opentelemetry-instrumentation-boto3sqs==0.52b0
-opentelemetry-instrumentation-botocore==0.52b0
-opentelemetry-instrumentation-click==0.52b0
-opentelemetry-instrumentation-elasticsearch==0.52b0
-opentelemetry-instrumentation-flask==0.52b0
-opentelemetry-instrumentation-grpc==0.52b0
-opentelemetry-instrumentation-httpx==0.52b0
-opentelemetry-instrumentation-jinja2==0.52b0
-opentelemetry-instrumentation-requests==0.52b0
-opentelemetry-instrumentation-sqlalchemy==0.52b0
-opentelemetry-instrumentation-system-metrics==0.52b0
-opentelemetry-instrumentation-tortoiseorm==0.52b0
-opentelemetry-instrumentation-urllib3==0.52b0
+opentelemetry-instrumentation-asyncio==0.52b1
+opentelemetry-instrumentation-dbapi==0.52b1
+opentelemetry-instrumentation-logging==0.52b1
+opentelemetry-instrumentation-sqlite3==0.52b1
+opentelemetry-instrumentation-threading==0.52b1
+opentelemetry-instrumentation-urllib==0.52b1
+opentelemetry-instrumentation-wsgi==0.52b1
+opentelemetry-instrumentation-vertexai>=2.0b0
+opentelemetry-instrumentation-aiohttp-client==0.52b1
+opentelemetry-instrumentation-aiohttp-server==0.52b1
+opentelemetry-instrumentation-boto3sqs==0.52b1
+opentelemetry-instrumentation-botocore==0.52b1
+opentelemetry-instrumentation-click==0.52b1
+opentelemetry-instrumentation-elasticsearch==0.52b1
+opentelemetry-instrumentation-flask==0.52b1
+opentelemetry-instrumentation-grpc==0.52b1
+opentelemetry-instrumentation-httpx==0.52b1
+opentelemetry-instrumentation-jinja2==0.52b1
+opentelemetry-instrumentation-requests==0.52b1
+opentelemetry-instrumentation-sqlalchemy==0.52b1
+opentelemetry-instrumentation-system-metrics==0.52b1
+opentelemetry-instrumentation-tortoiseorm==0.52b1
+opentelemetry-instrumentation-urllib3==0.52b1
 elastic-opentelemetry-instrumentation-openai

--- a/example-apps/chatbot-rag-app/requirements.txt
+++ b/example-apps/chatbot-rag-app/requirements.txt
@@ -20,11 +20,11 @@ attrs==25.3.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-boto3==1.37.13
+boto3==1.37.15
     # via
     #   langchain-aws
     #   langtrace-python-sdk
-botocore==1.37.13
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -103,7 +103,7 @@ google-auth==2.38.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.84.0
+google-cloud-aiplatform==1.85.0
     # via langchain-google-vertexai
 google-cloud-bigquery==3.30.0
     # via google-cloud-aiplatform
@@ -117,7 +117,7 @@ google-cloud-storage==2.19.0
     # via
     #   google-cloud-aiplatform
     #   langchain-google-vertexai
-google-crc32c==1.6.0
+google-crc32c==1.7.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
@@ -132,8 +132,6 @@ googleapis-common-protos[grpc]==1.69.2
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.1.1
-    # via sqlalchemy
 grpc-google-iam-v1==0.14.2
     # via google-cloud-resource-manager
 grpcio==1.71.0
@@ -190,15 +188,15 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.3.20
+langchain==0.3.21
     # via
     #   -r requirements.in
     #   langchain-community
-langchain-aws==0.2.15
+langchain-aws==0.2.16
     # via -r requirements.in
 langchain-cohere==0.4.3
     # via -r requirements.in
-langchain-community==0.3.19
+langchain-community==0.3.20
     # via langchain-cohere
 langchain-core==0.3.45
     # via
@@ -217,16 +215,16 @@ langchain-google-vertexai==2.0.15
     # via -r requirements.in
 langchain-mistralai==0.2.8
     # via -r requirements.in
-langchain-openai==0.3.8
+langchain-openai==0.3.9
     # via -r requirements.in
-langchain-text-splitters==0.3.6
+langchain-text-splitters==0.3.7
     # via langchain
-langsmith==0.3.15
+langsmith==0.3.17
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
-langtrace-python-sdk==3.8.6
+langtrace-python-sdk==3.8.7
     # via -r requirements.in
 log-symbols==0.0.14
     # via halo
@@ -236,7 +234,7 @@ markupsafe==3.0.2
     #   werkzeug
 marshmallow==3.26.1
     # via dataclasses-json
-multidict==6.1.0
+multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
@@ -249,7 +247,7 @@ numpy==2.2.4
     #   langchain-community
     #   shapely
     #   transformers
-openai==1.66.3
+openai==1.66.5
     # via langchain-openai
 opentelemetry-api==1.31.0
     # via
@@ -529,4 +527,4 @@ opentelemetry-instrumentation-sqlalchemy==0.52b0
 opentelemetry-instrumentation-system-metrics==0.52b0
 opentelemetry-instrumentation-tortoiseorm==0.52b0
 opentelemetry-instrumentation-urllib3==0.52b0
-elastic-opentelemetry-instrumentation-openai==0.6.1
+elastic-opentelemetry-instrumentation-openai


### PR DESCRIPTION
Last update left a pinned version of openai instrumentation, but recent EDOT unpins it. I regenerated the requirements.txt from the README so that updates flow through as we make them.

<img width="1246" alt="Screenshot 2025-03-19 at 10 08 35 AM" src="https://github.com/user-attachments/assets/6c57d07e-1a5e-49df-af26-d1e5f4da789f" />

Note: opentelemetry-instrumentation-vertexai is bootstrapped with EDOT GA, but it lacks streaming support so we still need langtrace.