### PR TITLE
Update documentation to highlight that copy_to is not required

### DIFF
--- a/notebooks/search/09-semantic-text.ipynb
+++ b/notebooks/search/09-semantic-text.ipynb
@@ -402,7 +402,7 @@
     "The `inference_id` parameter defines the inference endpoint that is used to generate the embeddings for the field.\n",
     "Then we configured the `plot` field to [copy its value](https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html) to the `plot_semantic` field.\n",
     "\n",
-    "While the use of `copy_to` is not required to leverage semantic search it does enable use cases like hybrid search where semantic and lexical techniques are used together. The contents of the `plot` field are copied into the `plot_semantic` field which enables searches over both fields at once."
+    "While `copy_to` is not required to use `semantic_text`, it enables use cases like hybrid search where semantic and lexical techniques are used together. We will cover a hybrid search example later in this notebook."
    ]
   },
   {
@@ -615,7 +615,7 @@
     "These results demonstrate that the application of lexical search techniques can help focus the results, while retaining many of the advantages of semantic search.\n",
     "In this example, the top search results are all still movies involving organized crime, but the `multi_match` query keeps the long tail shorter and focused on movies in the crime genre.\n",
     "\n",
-    "Notice how we specify the `plot` field in the multi_match query. The content of this field is also contained in the semantic field `plot_semantic` due to the use of `copy_to` this allows the boolean query to consider both lexical and semantic similarity of the `plot` field.\n",
+    "The `copy_to` parameter we defined in the mapping enables this query pattern. It ensures that the content provided for the `plot` field is indexed both lexically and semantically.\n",
     "\n",
     "Note the `boost` parameters applied to the `multi_match` and `semantic` queries.\n",
     "Combining lexical and semantic search techniques in a boolean query like this is called \"linear combination\" and when doing this, it is important to normalize the scores of the component queries.\n",

--- a/notebooks/search/09-semantic-text.ipynb
+++ b/notebooks/search/09-semantic-text.ipynb
@@ -400,7 +400,9 @@
    "source": [
     "Notice how we configured the mappings. We defined `plot_semantic` as a `semantic_text` field.\n",
     "The `inference_id` parameter defines the inference endpoint that is used to generate the embeddings for the field.\n",
-    "Then we configured the `plot` field to [copy its value](https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html) to the `plot_semantic` field."
+    "Then we configured the `plot` field to [copy its value](https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html) to the `plot_semantic` field.\n",
+    "\n",
+    "While the use of `copy_to` is not required to leverage semantic search it does enable use cases like hybrid search where semantic and lexical techniques are used together. The contents of the `plot` field are copied into the `plot_semantic` field which enables searches over both fields at once."
    ]
   },
   {
@@ -612,6 +614,8 @@
    "source": [
     "These results demonstrate that the application of lexical search techniques can help focus the results, while retaining many of the advantages of semantic search.\n",
     "In this example, the top search results are all still movies involving organized crime, but the `multi_match` query keeps the long tail shorter and focused on movies in the crime genre.\n",
+    "\n",
+    "Notice how we specify the `plot` field in the multi_match query. The content of this field is also contained in the semantic field `plot_semantic` due to the use of `copy_to` this allows the boolean query to consider both lexical and semantic similarity of the `plot` field.\n",
     "\n",
     "Note the `boost` parameters applied to the `multi_match` and `semantic` queries.\n",
     "Combining lexical and semantic search techniques in a boolean query like this is called \"linear combination\" and when doing this, it is important to normalize the scores of the component queries.\n",


### PR DESCRIPTION
Updating the documentation to highlight 
- `copy_to` is not required for semantic search
- How `copy_to` enable us to utilize lexical and semantic search together.

