### PR TITLE
Bump to 8.18 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         es_stack:
-          - 8.16.1
-          - 8.17.0
-          - 8.18.0-SNAPSHOT
+          - 8.17.5
+          - 8.18.0
+          - 8.19.0-SNAPSHOT
     runs-on: ubuntu-latest
     services:
       elasticsearch:


### PR DESCRIPTION
Bumping testing script to use public 8.18.0 release