### PR TITLE
edot: reduces overrides in docker and k8s example config

### DIFF
--- a/docker/docker-compose-elastic.yml
+++ b/docker/docker-compose-elastic.yml
@@ -36,8 +36,7 @@ configs:
           traces_dynamic_index:
             enabled: true
           flush:
-              bytes: 1048576  # apm-server default instead of 5000000
-              interval: 1s  # apm-server default instead of 30s
+            interval: 1s  # improve responsiveness in example apps (default 30s)
       
       service:
         pipelines:

--- a/k8s/k8s-manifest-elastic.yml
+++ b/k8s/k8s-manifest-elastic.yml
@@ -184,8 +184,7 @@ data:
         traces_dynamic_index:
           enabled: true
         flush:
-          bytes: 1048576  # apm-server default instead of 5000000
-          interval: 1s    # apm-server default instead of 30s
+          interval: 1s  # improve responsiveness in example apps (default 30s)
     service:
       pipelines:
         traces:


### PR DESCRIPTION
This removes the override for flush bytes as interestingly the apm-server one applied to compressed data
This also removes the apm-server anecdote replacing it with a valid purpose here.

Example apps are not likely to produce 5000000 bytes of data. This means you won't see a trace in kibana for 30s after whatever the interval is on the app exporter side (usually overridden to be a few seconds). Unless you reduce the collector-side interval, demos done by solutions architects, devrels and engineers will suffer. Also, any arbitrary people trying this will likely wonder why nothing is in kibana. Hence, regardless of this being the apm-server default, it makes sense to reduce this to 1s.