### PR TITLE
chatbot-rag-app: updates README to warn about quoting hazard

### DIFF
--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -91,7 +91,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.default.svc:4318
 
 *Note*: Do not add quotes to your `.env` file, as they are loaded raw in
 Kubernetes.
-Do this: `OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer xyz`
+Do this: `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer xyz`
 Not this: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer xyz"`
 
 Then, import your `.env` file as a configmap like this:

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -89,6 +89,12 @@ ELASTICSEARCH_URL=http://elasticsearch.default.svc:9200
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.default.svc:4318
 ```
 
+*Note*: Do not add quotes to your `.env` file, as they are loaded raw in
+Kubernetes.
+Do this: `OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer xyz`
+Not this: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer xyz"`
+
+
 Then, import your `.env` file as a configmap like this:
 ```bash
 kubectl create configmap chatbot-rag-app-env --from-env-file=.env

--- a/example-apps/chatbot-rag-app/README.md
+++ b/example-apps/chatbot-rag-app/README.md
@@ -94,7 +94,6 @@ Kubernetes.
 Do this: `OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer xyz`
 Not this: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer xyz"`
 
-
 Then, import your `.env` file as a configmap like this:
 ```bash
 kubectl create configmap chatbot-rag-app-env --from-env-file=.env


### PR DESCRIPTION
Quoting can result in crashes from otel or elastic when ENV variables are loaded in a config map. This warns about a tricky failure case.