### PR TITLE
Fix LTR notebook in Google Collab

### DIFF
--- a/notebooks/search/08-learning-to-rank.ipynb
+++ b/notebooks/search/08-learning-to-rank.ipynb
@@ -48,7 +48,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU elasticsearch eland \"eland[scikit-learn]\" xgboost tqdm\n",
+    "!pip install -U elasticsearch eland \"eland[scikit-learn]\" xgboost tqdm\n",
     "\n",
     "from tqdm import tqdm\n",
     "\n",


### PR DESCRIPTION
The `q` param prevent Google collab to detect change in numpy and prompt for a restart. The user experience feels broken.