### PR TITLE
Update App Search Exporter Notebook for using `elasticsearch8` Package

### DIFF
--- a/notebooks/enterprise-search/app-search-engine-exporter.ipynb
+++ b/notebooks/enterprise-search/app-search-engine-exporter.ipynb
@@ -989,7 +989,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
The App Search exporter notebook was not working as-is due to the `elasticsearch` Python package for Elasticsearch 9.x, which was incompatible with 8.x (for App Search). This PR fixes this by using the `elasticsearch8` package.
