### PR TITLE
chore: black-format audio similarity search notebook

### DIFF
--- a/notebooks/integrations/gemini/audio_similarity_search_gemini_elasticsearch.ipynb
+++ b/notebooks/integrations/gemini/audio_similarity_search_gemini_elasticsearch.ipynb
@@ -1,567 +1,569 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0001",
-      "metadata": {},
-      "source": [
-        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/gemini/audio_similarity_search_gemini_elasticsearch.ipynb)\n",
-        "\n",
-        "# Audio Similarity Search with Gemini 2 Embeddings and Elasticsearch\n",
-        "\n",
-        "This notebook walks through building an audio similarity search pipeline using:\n",
-        "\n",
-        "- [**Gemini Embedding 2**](https://ai.google.dev/gemini-api/docs/embeddings#embed-audio) to generate vector embeddings from different modalities, such as text, images, audio, and video\n",
-        "- [**Elasticsearch**](https://www.elastic.co/elasticsearch) as a vector database for similarity search\n",
-        "\n",
-        "Music similarity has commonly been done in the past by converting the audio first to the frequency domain. (See this [audio similarity search tutorial](https://www.elastic.co/search-labs/blog/searching-by-music-leveraging-vector-search-audio-information-retrieval)) Frequency-domain representations like spectrograms capture tonal and rhythmic patterns, making it easier to identify similar-sounding music.\n",
-        "\n",
-        "With modern omni-modal embedding models, such as Gemini Embedding 2, you can pass audio files directly to the model without prior preprocessing of the audio data.\n",
-        "\n",
-        "In this tutorial, you'll see how this technique can be used to retrieve audio files that closely match the user's intent. You'll learn how to retrieve matching audio files based on a text description, or retrieve music best matching another piece of music, regardless of the instrument\n",
-        "\n",
-        "![Audio Similarity Search Diagram](../../../img/audio-similarity-search.png)\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0002",
-      "metadata": {},
-      "source": [
-        "## 1. Prerequisites\n",
-        "\n",
-        "First, you need to install the following packages into your virtual environment.\n",
-        "\n",
-        "```\n",
-        "python3 -m venv .venv\n",
-        "source .venv/bin/activate\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "a1b2c3d4-0003",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m26.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1\u001b[0m\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install -qU elasticsearch google-genai python-dotenv"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0004",
-      "metadata": {},
-      "source": [
-        "To follow this tutorial, you will need the following API keys set in your environment variables, Google Colab secrets, or `.env` file in your project root:\n",
-        "\n",
-        "- `GOOGLE_API_KEY`: Go to [Google AI Studio](https://aistudio.google.com/) → **Get API key** \n",
-        "- `ELASTICSEARCH_URL` and `ELASTICSEARCH_API_KEY`: see below. | Covered in the next section |\n",
-        "\n",
-        "You can choose one of the two options below to connect to an Elasticsearch instance:\n",
-        "- **Option 1: Elastic Cloud Serverless (recommended)** Go to [cloud.elastic.co](https://cloud.elastic.co/),  create a Serverless project, **Security → API keys** \n",
-        "- **Option 2: Local Docker**: Run the start-local script to spin up Elasticsearch and Kibana via Docker Compose in one command:\n",
-        "```bash\n",
-        "curl -fsSL https://elastic.co/start-local | sh\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "a1b2c3d4-0005",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "from dotenv import load_dotenv\n",
-        "\n",
-        "load_dotenv()\n",
-        "\n",
-        "GOOGLE_API_KEY = os.getenv(\"GOOGLE_API_KEY\")\n",
-        "ELASTICSEARCH_URL = os.getenv(\"ELASTICSEARCH_URL\")\n",
-        "ELASTICSEARCH_API_KEY = os.getenv(\"ELASTICSEARCH_API_KEY\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0006",
-      "metadata": {},
-      "source": [
-        "## 2. Set up Elasticsearch\n",
-        "\n",
-        "Connect to your Elasticsearch instance via the Python client."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "a1b2c3d4-0007",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Connected to Elasticsearch 9.5.0\n"
-          ]
-        }
-      ],
-      "source": [
-        "from elasticsearch import Elasticsearch\n",
-        "\n",
-        "es_client = Elasticsearch(\n",
-        "    hosts=[ELASTICSEARCH_URL],\n",
-        "    api_key=ELASTICSEARCH_API_KEY,\n",
-        ")\n",
-        "\n",
-        "print(\"Connected to Elasticsearch\", es_client.info()[\"version\"][\"number\"])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0008",
-      "metadata": {},
-      "source": [
-        "## 3. Data Preparation\n",
-        "\n",
-        "We'll be using the same small toy example dataset from  this [audio similarity search tutorial](https://www.elastic.co/search-labs/blog/searching-by-music-leveraging-vector-search-audio-information-retrieval). The dataset contains 18 `.wav` files containing the same two pieces (*Bella Ciao* and *Mozart Symphony No. 25*), each rendered in a different style (piano solo, guitar solo, and more)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "a1b2c3d4-0009",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Downloaded: a-cappella-chorus.wav\n",
-            "Downloaded: bella_ciao_a-cappella-chorus.wav\n",
-            "Downloaded: bella_ciao_electronic-synth-lead.wav\n",
-            "Downloaded: bella_ciao_guitar-solo.wav\n",
-            "Downloaded: bella_ciao_humming.wav\n",
-            "Downloaded: bella_ciao_jazz-with-saxophone.wav\n",
-            "Downloaded: bella_ciao_opera-singer.wav\n",
-            "Downloaded: bella_ciao_piano-solo.wav\n",
-            "Downloaded: bella_ciao_string-quartet.wav\n",
-            "Downloaded: bella_ciao_tribal-drums-and-flute.wav\n",
-            "Downloaded: mozart_symphony25_electronic-synth-lead.wav\n",
-            "Downloaded: mozart_symphony25_guitar-solo.wav\n",
-            "Downloaded: mozart_symphony25_jazz-with-saxophone.wav\n",
-            "Downloaded: mozart_symphony25_opera-singer.wav\n",
-            "Downloaded: mozart_symphony25_piano-solo.wav\n",
-            "Downloaded: mozart_symphony25_prompt.wav\n",
-            "Downloaded: mozart_symphony25_string-quartet.wav\n",
-            "Downloaded: mozart_symphony25_tribal-drums-and-flute.wav\n",
-            "All 18 files downloaded to data/\n"
-          ]
-        }
-      ],
-      "source": [
-        "import urllib.request\n",
-        "from pathlib import Path\n",
-        "\n",
-        "DATA_DIR = Path(\"data\")\n",
-        "DATA_DIR.mkdir(exist_ok=True)\n",
-        "\n",
-        "BASE_URL = \"https://raw.githubusercontent.com/salgado/music-search/main/dataset/\"\n",
-        "\n",
-        "# Download all contents from BASE_URL\n",
-        "# This downloads just the .wav files found in the remote directory listing (assume known list since no directory listing available)\n",
-        "audio_files = [\n",
-        "    \"a-cappella-chorus.wav\",\n",
-        "    \"bella_ciao_a-cappella-chorus.wav\",\n",
-        "    \"bella_ciao_electronic-synth-lead.wav\",\n",
-        "    \"bella_ciao_guitar-solo.wav\",\n",
-        "    \"bella_ciao_humming.wav\",\n",
-        "    \"bella_ciao_jazz-with-saxophone.wav\",\n",
-        "    \"bella_ciao_opera-singer.wav\",\n",
-        "    \"bella_ciao_piano-solo.wav\",\n",
-        "    \"bella_ciao_string-quartet.wav\",\n",
-        "    \"bella_ciao_tribal-drums-and-flute.wav\",\n",
-        "    \"mozart_symphony25_electronic-synth-lead.wav\",\n",
-        "    \"mozart_symphony25_guitar-solo.wav\",\n",
-        "    \"mozart_symphony25_jazz-with-saxophone.wav\",\n",
-        "    \"mozart_symphony25_opera-singer.wav\",\n",
-        "    \"mozart_symphony25_piano-solo.wav\",\n",
-        "    \"mozart_symphony25_prompt.wav\",\n",
-        "    \"mozart_symphony25_string-quartet.wav\",\n",
-        "    \"mozart_symphony25_tribal-drums-and-flute.wav\",\n",
-        "]\n",
-        "\n",
-        "for filename in audio_files:\n",
-        "    file_url = BASE_URL + filename\n",
-        "    dest_path = DATA_DIR / filename\n",
-        "    urllib.request.urlretrieve(file_url, dest_path)\n",
-        "    print(f\"Downloaded: {filename}\")\n",
-        "\n",
-        "print(f\"All {len(audio_files)} files downloaded to {DATA_DIR}/\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0010",
-      "metadata": {},
-      "source": [
-        "## 4. Define the Index Mapping\n",
-        "\n",
-        "We create an Elasticsearch index with two fields:\n",
-        "\n",
-        "- `filename` (`keyword`): Exact identifier for the audio file\n",
-        "- `audio_embedding` (`dense_vector`): The vector used for kNN similarity search\n",
-        "\n",
-        "Setting `similarity: cosine` tells Elasticsearch to rank results by cosine similarity. \n",
-        "\n",
-        "*Note:* We omit the `dims` parameter here. Elasticsearch will automatically infer the vector dimension from the first document indexed, so you don't need to know it upfront."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "a1b2c3d4-0011",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Index 'audio-search' created.\n"
-          ]
-        }
-      ],
-      "source": [
-        "INDEX_NAME = \"audio-search\"\n",
-        "\n",
-        "# Drop the index only if it already exists so this cell is safely re-runnable\n",
-        "if es_client.indices.exists(index=INDEX_NAME):\n",
-        "    es_client.indices.delete(index=INDEX_NAME)\n",
-        "\n",
-        "es_client.indices.create(\n",
-        "    index=INDEX_NAME,\n",
-        "    mappings={\n",
-        "        \"properties\": {\n",
-        "            \"filename\": {\"type\": \"keyword\"},\n",
-        "            \"audio_embedding\": {\n",
-        "                \"type\": \"dense_vector\",\n",
-        "                \"similarity\": \"cosine\",\n",
-        "            },\n",
-        "        }\n",
-        "    },\n",
-        ")\n",
-        "\n",
-        "print(f\"Index '{INDEX_NAME}' created.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0012",
-      "metadata": {},
-      "source": [
-        "## 5. Set up `genai` Client for Gemini 2 Embeddings\n",
-        "\n",
-        "Gemini Embedding 2 is a **multimodal** model: it encodes audio and text into the **same vector space**. This shared space is what makes cross-modal queries possible. For example, a text description of a mood can retrieve acoustically matching audio, and vice versa.\n",
-        "\n",
-        "In this tutorial, we will focus on two modalities: text and audio. \n",
-        "\n",
-        "We define two small helper functions, one per input modality."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "a1b2c3d4-0013",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from google import genai\n",
-        "from google.genai import types\n",
-        "\n",
-        "google_client = genai.Client(api_key=GOOGLE_API_KEY)\n",
-        "\n",
-        "def embed_audio(filepath: str) -> list[float]:\n",
-        "    with open(filepath, \"rb\") as f:\n",
-        "        audio_bytes = f.read()\n",
-        "\n",
-        "    result = google_client.models.embed_content(\n",
-        "        model=\"gemini-embedding-2\",\n",
-        "        contents=[\n",
-        "            types.Part.from_bytes(\n",
-        "                data=audio_bytes,\n",
-        "                mime_type=\"audio/wav\",\n",
-        "            )\n",
-        "        ],\n",
-        "    )\n",
-        "    return result.embeddings[0].values\n",
-        "\n",
-        "\n",
-        "def embed_text(text: str) -> list[float]:\n",
-        "    result = google_client.models.embed_content(\n",
-        "        model=\"gemini-embedding-2\",\n",
-        "        contents=text,\n",
-        "    )\n",
-        "    return result.embeddings[0].values"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "651df4ea",
-      "metadata": {},
-      "source": [
-        "Let's the functions to embed the contents."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "797a65f1",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Text embedding:\n",
-            "[-0.022495363, 0.004016586, 0.02667887, -0.008154897, -0.018237598, 0.013646618, -0.006213285, 0.016268833, -0.005994342, -0.048850574]\n",
-            "Audio embedding:\n",
-            "[-0.035680573, 0.014103874, 0.013038295, -0.021932071, 0.013883692, 0.0040342035, -0.013924922, 0.016876323, 0.0029246118, -0.055127673]\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(\"Text embedding:\")\n",
-        "text_embedding = embed_text(\"Hello, world!\")\n",
-        "print(text_embedding[:10])\n",
-        "\n",
-        "print(\"Audio embedding:\")\n",
-        "audio_embedding = embed_audio(\"data/a-cappella-chorus.wav\")\n",
-        "print(audio_embedding[:10])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0014",
-      "metadata": {},
-      "source": [
-        "## 6. Ingest the data\n",
-        "\n",
-        "We loop over each audio file, generate an embedding, and stream the documents into Elasticsearch using the bulk helper. The generator pattern keeps memory usage flat regardless of how many files you have."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "id": "a1b2c3d4-0015",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Embedding a-cappella-chorus.wav...\n",
-            "Embedding bella_ciao_a-cappella-chorus.wav...\n",
-            "Embedding bella_ciao_electronic-synth-lead.wav...\n",
-            "Embedding bella_ciao_guitar-solo.wav...\n",
-            "Embedding bella_ciao_humming.wav...\n",
-            "Embedding bella_ciao_jazz-with-saxophone.wav...\n",
-            "Embedding bella_ciao_opera-singer.wav...\n",
-            "Embedding bella_ciao_piano-solo.wav...\n",
-            "Embedding bella_ciao_string-quartet.wav...\n",
-            "Embedding bella_ciao_tribal-drums-and-flute.wav...\n",
-            "Embedding mozart_symphony25_electronic-synth-lead.wav...\n",
-            "Embedding mozart_symphony25_guitar-solo.wav...\n",
-            "Embedding mozart_symphony25_jazz-with-saxophone.wav...\n",
-            "Embedding mozart_symphony25_opera-singer.wav...\n",
-            "Embedding mozart_symphony25_piano-solo.wav...\n",
-            "Embedding mozart_symphony25_prompt.wav...\n",
-            "Embedding mozart_symphony25_string-quartet.wav...\n",
-            "Embedding mozart_symphony25_tribal-drums-and-flute.wav...\n",
-            "\n",
-            "Indexed 18 documents.\n"
-          ]
-        }
-      ],
-      "source": [
-        "from elasticsearch.helpers import bulk\n",
-        "\n",
-        "def generate_docs(file_paths):\n",
-        "    for file_path in file_paths:\n",
-        "        print(f\"Embedding {file_path}...\")\n",
-        "        embedding = embed_audio(f\"data/{file_path}\")\n",
-        "   \n",
-        "        yield {\n",
-        "            \"_index\": INDEX_NAME,\n",
-        "            \"_id\": file_path,\n",
-        "            \"filename\": file_path,\n",
-        "            \"audio_embedding\": embedding,\n",
-        "        }\n",
-        "\n",
-        "\n",
-        "count, _ = bulk(es_client, generate_docs(audio_files))\n",
-        "print(f\"\\nIndexed {count} documents.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0016",
-      "metadata": {},
-      "source": [
-        "## 7. Sample Search Queries\n",
-        "\n",
-        "Let's test two example queries: one for text queries and one for audio queries.\n",
-        "\n",
-        "Both queries use the Elasticsearch [kNN retriever](https://www.elastic.co/docs/solutions/search/vector/knn). The key parameters:\n",
-        "\n",
-        "- `k`: number of results to return\n",
-        "- `num_candidates`: how many candidates each shard considers before returning the top `k` (higher = more accurate, slower)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0017",
-      "metadata": {},
-      "source": [
-        "### Text Search Query: (Text-to-audio)\n",
-        "\n",
-        "Embed a natural language description and retrieve the most similar audio tracks. \n",
-        "\n",
-        "Below you can see that for the search query of \"Jazz music\", the top 2 search results are the Jazz-style rendered versions of the two different tracks."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "id": "a1b2c3d4-0018",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Top matches for 'Jazz music':\n"
-          ]
-        }
-      ],
-      "source": [
-        "query_text = \"Jazz music\"\n",
-        "\n",
-        "response = es_client.search(\n",
-        "    index=INDEX_NAME,\n",
-        "    retriever={\n",
-        "        \"knn\": {\n",
-        "            \"field\": \"audio_embedding\",\n",
-        "            \"query_vector\": embed_text(query_text),\n",
-        "            \"k\": 3,\n",
-        "            \"num_candidates\": 5,\n",
-        "        }\n",
-        "    },\n",
-        ")\n",
-        "\n",
-        "print(f\"Top matches for '{query_text}':\")\n",
-        "for hit in response[\"hits\"][\"hits\"]:\n",
-        "    print(f\"  [{hit['_score']:.4f}] {hit['_source']['filename']}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0019",
-      "metadata": {},
-      "source": [
-        "### Audio Search Query (Audio-to-audio)\n",
-        "\n",
-        "Embed a reference audio file and find the most acoustically similar tracks in the index.\n",
-        "\n",
-        "Note, we're using a file that has been indexed here. Usually, search queries are not in the index. You can replace `QUERY_AUDIO_PATH` with any `.wav` file on your machine."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "a1b2c3d4-0020",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Top matches for 'data/a-cappella-chorus.wav':\n",
-            "  [1.0000] a-cappella-chorus.wav\n",
-            "  [0.8408] bella_ciao_electronic-synth-lead.wav\n",
-            "  [0.8291] mozart_symphony25_tribal-drums-and-flute.wav\n"
-          ]
-        }
-      ],
-      "source": [
-        "QUERY_AUDIO_PATH = str(DATA_DIR / \"a-cappella-chorus.wav\")\n",
-        "\n",
-        "response = es_client.search(\n",
-        "    index=INDEX_NAME,\n",
-        "    retriever={\n",
-        "        \"knn\": {\n",
-        "            \"field\": \"audio_embedding\",\n",
-        "            \"query_vector\": embed_audio(QUERY_AUDIO_PATH),\n",
-        "            \"k\": 3,\n",
-        "            \"num_candidates\": 18,\n",
-        "        }\n",
-        "    },\n",
-        ")\n",
-        "\n",
-        "print(f\"Top matches for '{QUERY_AUDIO_PATH}':\")\n",
-        "for hit in response[\"hits\"][\"hits\"]:\n",
-        "    print(f\"  [{hit['_score']:.4f}] {hit['_source']['filename']}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a1b2c3d4-0021",
-      "metadata": {},
-      "source": [
-        "## Summary\n",
-        "\n",
-        "This tutorial gave you a quick overview of how you can do a simple multimodal search over audio data with text-to-audio and audio-to-audio queries.\n",
-        "\n",
-        "### References\n",
-        "\n",
-        "- [Bring your own dense vectors to Elasticsearch](https://www.elastic.co/docs/solutions/search/vector/bring-own-vectors)\n",
-        "- [kNN search in Elasticsearch](https://www.elastic.co/docs/solutions/search/vector/knn)\n",
-        "- [Dense vector field type reference](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector)\n",
-        "- [Gemini Embedding API](https://ai.google.dev/gemini-api/docs/embeddings)"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.14.3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001",
+   "metadata": {},
+   "source": [
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/integrations/gemini/audio_similarity_search_gemini_elasticsearch.ipynb)\n",
+    "\n",
+    "# Audio Similarity Search with Gemini 2 Embeddings and Elasticsearch\n",
+    "\n",
+    "This notebook walks through building an audio similarity search pipeline using:\n",
+    "\n",
+    "- [**Gemini Embedding 2**](https://ai.google.dev/gemini-api/docs/embeddings#embed-audio) to generate vector embeddings from different modalities, such as text, images, audio, and video\n",
+    "- [**Elasticsearch**](https://www.elastic.co/elasticsearch) as a vector database for similarity search\n",
+    "\n",
+    "Music similarity has commonly been done in the past by converting the audio first to the frequency domain. (See this [audio similarity search tutorial](https://www.elastic.co/search-labs/blog/searching-by-music-leveraging-vector-search-audio-information-retrieval)) Frequency-domain representations like spectrograms capture tonal and rhythmic patterns, making it easier to identify similar-sounding music.\n",
+    "\n",
+    "With modern omni-modal embedding models, such as Gemini Embedding 2, you can pass audio files directly to the model without prior preprocessing of the audio data.\n",
+    "\n",
+    "In this tutorial, you'll see how this technique can be used to retrieve audio files that closely match the user's intent. You'll learn how to retrieve matching audio files based on a text description, or retrieve music best matching another piece of music, regardless of the instrument\n",
+    "\n",
+    "![Audio Similarity Search Diagram](../../../img/audio-similarity-search.png)\n",
+    "\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0002",
+   "metadata": {},
+   "source": [
+    "## 1. Prerequisites\n",
+    "\n",
+    "First, you need to install the following packages into your virtual environment.\n",
+    "\n",
+    "```\n",
+    "python3 -m venv .venv\n",
+    "source .venv/bin/activate\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a1b2c3d4-0003",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m26.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -qU elasticsearch google-genai python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0004",
+   "metadata": {},
+   "source": [
+    "To follow this tutorial, you will need the following API keys set in your environment variables, Google Colab secrets, or `.env` file in your project root:\n",
+    "\n",
+    "- `GOOGLE_API_KEY`: Go to [Google AI Studio](https://aistudio.google.com/) → **Get API key** \n",
+    "- `ELASTICSEARCH_URL` and `ELASTICSEARCH_API_KEY`: see below. | Covered in the next section |\n",
+    "\n",
+    "You can choose one of the two options below to connect to an Elasticsearch instance:\n",
+    "- **Option 1: Elastic Cloud Serverless (recommended)** Go to [cloud.elastic.co](https://cloud.elastic.co/),  create a Serverless project, **Security → API keys** \n",
+    "- **Option 2: Local Docker**: Run the start-local script to spin up Elasticsearch and Kibana via Docker Compose in one command:\n",
+    "```bash\n",
+    "curl -fsSL https://elastic.co/start-local | sh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a1b2c3d4-0005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "GOOGLE_API_KEY = os.getenv(\"GOOGLE_API_KEY\")\n",
+    "ELASTICSEARCH_URL = os.getenv(\"ELASTICSEARCH_URL\")\n",
+    "ELASTICSEARCH_API_KEY = os.getenv(\"ELASTICSEARCH_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0006",
+   "metadata": {},
+   "source": [
+    "## 2. Set up Elasticsearch\n",
+    "\n",
+    "Connect to your Elasticsearch instance via the Python client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a1b2c3d4-0007",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to Elasticsearch 9.5.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from elasticsearch import Elasticsearch\n",
+    "\n",
+    "es_client = Elasticsearch(\n",
+    "    hosts=[ELASTICSEARCH_URL],\n",
+    "    api_key=ELASTICSEARCH_API_KEY,\n",
+    ")\n",
+    "\n",
+    "print(\"Connected to Elasticsearch\", es_client.info()[\"version\"][\"number\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008",
+   "metadata": {},
+   "source": [
+    "## 3. Data Preparation\n",
+    "\n",
+    "We'll be using the same small toy example dataset from  this [audio similarity search tutorial](https://www.elastic.co/search-labs/blog/searching-by-music-leveraging-vector-search-audio-information-retrieval). The dataset contains 18 `.wav` files containing the same two pieces (*Bella Ciao* and *Mozart Symphony No. 25*), each rendered in a different style (piano solo, guitar solo, and more)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a1b2c3d4-0009",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded: a-cappella-chorus.wav\n",
+      "Downloaded: bella_ciao_a-cappella-chorus.wav\n",
+      "Downloaded: bella_ciao_electronic-synth-lead.wav\n",
+      "Downloaded: bella_ciao_guitar-solo.wav\n",
+      "Downloaded: bella_ciao_humming.wav\n",
+      "Downloaded: bella_ciao_jazz-with-saxophone.wav\n",
+      "Downloaded: bella_ciao_opera-singer.wav\n",
+      "Downloaded: bella_ciao_piano-solo.wav\n",
+      "Downloaded: bella_ciao_string-quartet.wav\n",
+      "Downloaded: bella_ciao_tribal-drums-and-flute.wav\n",
+      "Downloaded: mozart_symphony25_electronic-synth-lead.wav\n",
+      "Downloaded: mozart_symphony25_guitar-solo.wav\n",
+      "Downloaded: mozart_symphony25_jazz-with-saxophone.wav\n",
+      "Downloaded: mozart_symphony25_opera-singer.wav\n",
+      "Downloaded: mozart_symphony25_piano-solo.wav\n",
+      "Downloaded: mozart_symphony25_prompt.wav\n",
+      "Downloaded: mozart_symphony25_string-quartet.wav\n",
+      "Downloaded: mozart_symphony25_tribal-drums-and-flute.wav\n",
+      "All 18 files downloaded to data/\n"
+     ]
+    }
+   ],
+   "source": [
+    "import urllib.request\n",
+    "from pathlib import Path\n",
+    "\n",
+    "DATA_DIR = Path(\"data\")\n",
+    "DATA_DIR.mkdir(exist_ok=True)\n",
+    "\n",
+    "BASE_URL = \"https://raw.githubusercontent.com/salgado/music-search/main/dataset/\"\n",
+    "\n",
+    "# Download all contents from BASE_URL\n",
+    "# This downloads just the .wav files found in the remote directory listing (assume known list since no directory listing available)\n",
+    "audio_files = [\n",
+    "    \"a-cappella-chorus.wav\",\n",
+    "    \"bella_ciao_a-cappella-chorus.wav\",\n",
+    "    \"bella_ciao_electronic-synth-lead.wav\",\n",
+    "    \"bella_ciao_guitar-solo.wav\",\n",
+    "    \"bella_ciao_humming.wav\",\n",
+    "    \"bella_ciao_jazz-with-saxophone.wav\",\n",
+    "    \"bella_ciao_opera-singer.wav\",\n",
+    "    \"bella_ciao_piano-solo.wav\",\n",
+    "    \"bella_ciao_string-quartet.wav\",\n",
+    "    \"bella_ciao_tribal-drums-and-flute.wav\",\n",
+    "    \"mozart_symphony25_electronic-synth-lead.wav\",\n",
+    "    \"mozart_symphony25_guitar-solo.wav\",\n",
+    "    \"mozart_symphony25_jazz-with-saxophone.wav\",\n",
+    "    \"mozart_symphony25_opera-singer.wav\",\n",
+    "    \"mozart_symphony25_piano-solo.wav\",\n",
+    "    \"mozart_symphony25_prompt.wav\",\n",
+    "    \"mozart_symphony25_string-quartet.wav\",\n",
+    "    \"mozart_symphony25_tribal-drums-and-flute.wav\",\n",
+    "]\n",
+    "\n",
+    "for filename in audio_files:\n",
+    "    file_url = BASE_URL + filename\n",
+    "    dest_path = DATA_DIR / filename\n",
+    "    urllib.request.urlretrieve(file_url, dest_path)\n",
+    "    print(f\"Downloaded: {filename}\")\n",
+    "\n",
+    "print(f\"All {len(audio_files)} files downloaded to {DATA_DIR}/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0010",
+   "metadata": {},
+   "source": [
+    "## 4. Define the Index Mapping\n",
+    "\n",
+    "We create an Elasticsearch index with two fields:\n",
+    "\n",
+    "- `filename` (`keyword`): Exact identifier for the audio file\n",
+    "- `audio_embedding` (`dense_vector`): The vector used for kNN similarity search\n",
+    "\n",
+    "Setting `similarity: cosine` tells Elasticsearch to rank results by cosine similarity. \n",
+    "\n",
+    "*Note:* We omit the `dims` parameter here. Elasticsearch will automatically infer the vector dimension from the first document indexed, so you don't need to know it upfront."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1b2c3d4-0011",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index 'audio-search' created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "INDEX_NAME = \"audio-search\"\n",
+    "\n",
+    "# Drop the index only if it already exists so this cell is safely re-runnable\n",
+    "if es_client.indices.exists(index=INDEX_NAME):\n",
+    "    es_client.indices.delete(index=INDEX_NAME)\n",
+    "\n",
+    "es_client.indices.create(\n",
+    "    index=INDEX_NAME,\n",
+    "    mappings={\n",
+    "        \"properties\": {\n",
+    "            \"filename\": {\"type\": \"keyword\"},\n",
+    "            \"audio_embedding\": {\n",
+    "                \"type\": \"dense_vector\",\n",
+    "                \"similarity\": \"cosine\",\n",
+    "            },\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "print(f\"Index '{INDEX_NAME}' created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0012",
+   "metadata": {},
+   "source": [
+    "## 5. Set up `genai` Client for Gemini 2 Embeddings\n",
+    "\n",
+    "Gemini Embedding 2 is a **multimodal** model: it encodes audio and text into the **same vector space**. This shared space is what makes cross-modal queries possible. For example, a text description of a mood can retrieve acoustically matching audio, and vice versa.\n",
+    "\n",
+    "In this tutorial, we will focus on two modalities: text and audio. \n",
+    "\n",
+    "We define two small helper functions, one per input modality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a1b2c3d4-0013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google import genai\n",
+    "from google.genai import types\n",
+    "\n",
+    "google_client = genai.Client(api_key=GOOGLE_API_KEY)\n",
+    "\n",
+    "\n",
+    "def embed_audio(filepath: str) -> list[float]:\n",
+    "    with open(filepath, \"rb\") as f:\n",
+    "        audio_bytes = f.read()\n",
+    "\n",
+    "    result = google_client.models.embed_content(\n",
+    "        model=\"gemini-embedding-2\",\n",
+    "        contents=[\n",
+    "            types.Part.from_bytes(\n",
+    "                data=audio_bytes,\n",
+    "                mime_type=\"audio/wav\",\n",
+    "            )\n",
+    "        ],\n",
+    "    )\n",
+    "    return result.embeddings[0].values\n",
+    "\n",
+    "\n",
+    "def embed_text(text: str) -> list[float]:\n",
+    "    result = google_client.models.embed_content(\n",
+    "        model=\"gemini-embedding-2\",\n",
+    "        contents=text,\n",
+    "    )\n",
+    "    return result.embeddings[0].values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "651df4ea",
+   "metadata": {},
+   "source": [
+    "Let's the functions to embed the contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "797a65f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Text embedding:\n",
+      "[-0.022495363, 0.004016586, 0.02667887, -0.008154897, -0.018237598, 0.013646618, -0.006213285, 0.016268833, -0.005994342, -0.048850574]\n",
+      "Audio embedding:\n",
+      "[-0.035680573, 0.014103874, 0.013038295, -0.021932071, 0.013883692, 0.0040342035, -0.013924922, 0.016876323, 0.0029246118, -0.055127673]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Text embedding:\")\n",
+    "text_embedding = embed_text(\"Hello, world!\")\n",
+    "print(text_embedding[:10])\n",
+    "\n",
+    "print(\"Audio embedding:\")\n",
+    "audio_embedding = embed_audio(\"data/a-cappella-chorus.wav\")\n",
+    "print(audio_embedding[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0014",
+   "metadata": {},
+   "source": [
+    "## 6. Ingest the data\n",
+    "\n",
+    "We loop over each audio file, generate an embedding, and stream the documents into Elasticsearch using the bulk helper. The generator pattern keeps memory usage flat regardless of how many files you have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a1b2c3d4-0015",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedding a-cappella-chorus.wav...\n",
+      "Embedding bella_ciao_a-cappella-chorus.wav...\n",
+      "Embedding bella_ciao_electronic-synth-lead.wav...\n",
+      "Embedding bella_ciao_guitar-solo.wav...\n",
+      "Embedding bella_ciao_humming.wav...\n",
+      "Embedding bella_ciao_jazz-with-saxophone.wav...\n",
+      "Embedding bella_ciao_opera-singer.wav...\n",
+      "Embedding bella_ciao_piano-solo.wav...\n",
+      "Embedding bella_ciao_string-quartet.wav...\n",
+      "Embedding bella_ciao_tribal-drums-and-flute.wav...\n",
+      "Embedding mozart_symphony25_electronic-synth-lead.wav...\n",
+      "Embedding mozart_symphony25_guitar-solo.wav...\n",
+      "Embedding mozart_symphony25_jazz-with-saxophone.wav...\n",
+      "Embedding mozart_symphony25_opera-singer.wav...\n",
+      "Embedding mozart_symphony25_piano-solo.wav...\n",
+      "Embedding mozart_symphony25_prompt.wav...\n",
+      "Embedding mozart_symphony25_string-quartet.wav...\n",
+      "Embedding mozart_symphony25_tribal-drums-and-flute.wav...\n",
+      "\n",
+      "Indexed 18 documents.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from elasticsearch.helpers import bulk\n",
+    "\n",
+    "\n",
+    "def generate_docs(file_paths):\n",
+    "    for file_path in file_paths:\n",
+    "        print(f\"Embedding {file_path}...\")\n",
+    "        embedding = embed_audio(f\"data/{file_path}\")\n",
+    "\n",
+    "        yield {\n",
+    "            \"_index\": INDEX_NAME,\n",
+    "            \"_id\": file_path,\n",
+    "            \"filename\": file_path,\n",
+    "            \"audio_embedding\": embedding,\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "count, _ = bulk(es_client, generate_docs(audio_files))\n",
+    "print(f\"\\nIndexed {count} documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0016",
+   "metadata": {},
+   "source": [
+    "## 7. Sample Search Queries\n",
+    "\n",
+    "Let's test two example queries: one for text queries and one for audio queries.\n",
+    "\n",
+    "Both queries use the Elasticsearch [kNN retriever](https://www.elastic.co/docs/solutions/search/vector/knn). The key parameters:\n",
+    "\n",
+    "- `k`: number of results to return\n",
+    "- `num_candidates`: how many candidates each shard considers before returning the top `k` (higher = more accurate, slower)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0017",
+   "metadata": {},
+   "source": [
+    "### Text Search Query: (Text-to-audio)\n",
+    "\n",
+    "Embed a natural language description and retrieve the most similar audio tracks. \n",
+    "\n",
+    "Below you can see that for the search query of \"Jazz music\", the top 2 search results are the Jazz-style rendered versions of the two different tracks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a1b2c3d4-0018",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top matches for 'Jazz music':\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_text = \"Jazz music\"\n",
+    "\n",
+    "response = es_client.search(\n",
+    "    index=INDEX_NAME,\n",
+    "    retriever={\n",
+    "        \"knn\": {\n",
+    "            \"field\": \"audio_embedding\",\n",
+    "            \"query_vector\": embed_text(query_text),\n",
+    "            \"k\": 3,\n",
+    "            \"num_candidates\": 5,\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "print(f\"Top matches for '{query_text}':\")\n",
+    "for hit in response[\"hits\"][\"hits\"]:\n",
+    "    print(f\"  [{hit['_score']:.4f}] {hit['_source']['filename']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0019",
+   "metadata": {},
+   "source": [
+    "### Audio Search Query (Audio-to-audio)\n",
+    "\n",
+    "Embed a reference audio file and find the most acoustically similar tracks in the index.\n",
+    "\n",
+    "Note, we're using a file that has been indexed here. Usually, search queries are not in the index. You can replace `QUERY_AUDIO_PATH` with any `.wav` file on your machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a1b2c3d4-0020",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top matches for 'data/a-cappella-chorus.wav':\n",
+      "  [1.0000] a-cappella-chorus.wav\n",
+      "  [0.8408] bella_ciao_electronic-synth-lead.wav\n",
+      "  [0.8291] mozart_symphony25_tribal-drums-and-flute.wav\n"
+     ]
+    }
+   ],
+   "source": [
+    "QUERY_AUDIO_PATH = str(DATA_DIR / \"a-cappella-chorus.wav\")\n",
+    "\n",
+    "response = es_client.search(\n",
+    "    index=INDEX_NAME,\n",
+    "    retriever={\n",
+    "        \"knn\": {\n",
+    "            \"field\": \"audio_embedding\",\n",
+    "            \"query_vector\": embed_audio(QUERY_AUDIO_PATH),\n",
+    "            \"k\": 3,\n",
+    "            \"num_candidates\": 18,\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "print(f\"Top matches for '{QUERY_AUDIO_PATH}':\")\n",
+    "for hit in response[\"hits\"][\"hits\"]:\n",
+    "    print(f\"  [{hit['_score']:.4f}] {hit['_source']['filename']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0021",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This tutorial gave you a quick overview of how you can do a simple multimodal search over audio data with text-to-audio and audio-to-audio queries.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- [Bring your own dense vectors to Elasticsearch](https://www.elastic.co/docs/solutions/search/vector/bring-own-vectors)\n",
+    "- [kNN search in Elasticsearch](https://www.elastic.co/docs/solutions/search/vector/knn)\n",
+    "- [Dense vector field type reference](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector)\n",
+    "- [Gemini Embedding API](https://ai.google.dev/gemini-api/docs/embeddings)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

Apply the repo-pinned `black==25.12.0` (via `black[jupyter]`) to `notebooks/integrations/gemini/audio_similarity_search_gemini_elasticsearch.ipynb`.

This notebook was added in #547 but currently fails the `black-jupyter` pre-commit hook when it runs `--all-files`, which blocks every subsequent PR's CI (for example, #552). The only semantic change is two PEP 8 blank lines added before module-level function definitions (`embed_audio`, `generate_docs`); the remaining diff is JSON indentation normalization that `black-jupyter` performs.

```bash
git diff -w --shortstat
#  1 file changed, 2 insertions(+)
```

## Test plan

- [ ] `pre-commit run --all-files black-jupyter` passes locally.
- [ ] CI `pre-commit` job goes green on this PR.


Made with [Cursor](https://cursor.com)