### PR TITLE
Add content for metric temporality blog

### DIFF
--- a/supporting-blog-content/elasticsearch-temporality-demo/Dockerfile.renaissance
+++ b/supporting-blog-content/elasticsearch-temporality-demo/Dockerfile.renaissance
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:21-jdk-jammy
+
+WORKDIR /demo
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL -o /demo/opentelemetry-javaagent.jar \
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+
+RUN curl -fsSL -o /demo/renaissance-gpl-0.16.1.jar \
+    https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.16.1/renaissance-gpl-0.16.1.jar
+
+ENTRYPOINT ["java", "-XX:+UseG1GC", "-javaagent:/demo/opentelemetry-javaagent.jar", "-jar", "/demo/renaissance-gpl-0.16.1.jar", "db-shootout", "--operation-run-seconds", "60000", "--no-forced-gc"]

--- a/supporting-blog-content/elasticsearch-temporality-demo/README.md
+++ b/supporting-blog-content/elasticsearch-temporality-demo/README.md
@@ -1,0 +1,52 @@
+# Elasticsearch OTLP JVM Metrics Demo
+
+This demo showcases both delta and cumulative metric temporality support in Elasticsearch.
+
+It runs two instances of the [Renaissance benchmark suite](https://renaissance.dev/) inside
+constrained Docker containers to stress the JVM and exports metrics with the vanilla
+[OpenTelemetry Java agent](https://opentelemetry.io/docs/zero-code/java/agent/).
+One instance is configured to use delta temporality, the other one uses cumulative.
+Those metrics are sent directly to the Elasticsearch OTLP endpoint.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- An Elasticsearch deployment that accepts OTLP ingest
+- An Elasticsearch API key with permissions to ingest data
+
+Helpful docs:
+
+- Elastic OTLP/HTTP ingest endpoint:  
+  [https://www.elastic.co/docs/manage-data/data-store/data-streams/tsds-ingest-otlp](https://www.elastic.co/docs/manage-data/data-store/data-streams/tsds-ingest-otlp)
+- Elastic API keys:  
+  [https://www.elastic.co/docs/deploy-manage/api-keys/elasticsearch-api-keys](https://www.elastic.co/docs/deploy-manage/api-keys/elasticsearch-api-keys)
+- OpenTelemetry environment variables:  
+  [https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+- OpenTelemetry Java agent:  
+  [https://opentelemetry.io/docs/zero-code/java/agent/](https://opentelemetry.io/docs/zero-code/java/agent/)
+
+## Configuration
+
+The key runtime settings are in `docker-compose.yml` under the `renaissance`
+service.
+
+At minimum, set:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` to your Elasticsearch OTLP endpoint
+  (for example `https://<cluster>/_otlp`)
+- `OTEL_EXPORTER_OTLP_HEADERS` with your API key in the format:
+  `Authorization=ApiKey <base64-key>`
+
+## Run the demo
+
+From the repository root:
+
+```bash
+docker compose up --build
+```
+
+The benchmarks will run for an hour or can be manually stopped with `Ctrl+C`, then optionally clean up:
+
+```bash
+docker compose down
+```

--- a/supporting-blog-content/elasticsearch-temporality-demo/docker-compose.yml
+++ b/supporting-blog-content/elasticsearch-temporality-demo/docker-compose.yml
@@ -1,0 +1,39 @@
+x-otlp-settings: &otlp-settings
+  OTEL_EXPORTER_OTLP_ENDPOINT: https://<cluster-endpoint>/_otlp
+  OTEL_EXPORTER_OTLP_HEADERS: "Authorization=ApiKey <base64 api key>"
+services:
+  renaissance-delta:
+    build:
+      context: .
+      dockerfile: Dockerfile.renaissance
+    cpus: "3.0"
+    mem_limit: 512m
+    environment:
+      <<: *otlp-settings
+      OTEL_SERVICE_NAME: renaissance
+      OTEL_RESOURCE_ATTRIBUTES: "service.instance.id=delta-instance"
+      OTEL_TRACES_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRIC_EXPORT_INTERVAL: 15000
+      OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
+      OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
+      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_ENABLED: "true"
+      
+  renaissance-cumulative:
+    build:
+      context: .
+      dockerfile: Dockerfile.renaissance
+    cpus: "3.0"
+    mem_limit: 512m
+    environment:
+      <<: *otlp-settings
+      OTEL_SERVICE_NAME: renaissance
+      OTEL_RESOURCE_ATTRIBUTES: "service.instance.id=cumulative-instance"
+      OTEL_TRACES_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_METRICS_EXPORTER: otlp
+      OTEL_METRIC_EXPORT_INTERVAL: 15000
+      OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: cumulative
+      OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
+      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_ENABLED: "true"


### PR DESCRIPTION
Adds the demo files for the blogpost about Elasticsearch metric temporality support.